### PR TITLE
Specify minimum node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ end
 First, your system on which you're running is going to need a couple of things:
 
 * [`ruby`](https://www.ruby-lang.org/en/documentation/installation/) `2.5` or newer - there are a lot of ways to install `ruby`, but I recommend [`rbenv`](https://github.com/rbenv/rbenv)
-* [`node`](https://nodejs.org/en/download/) - `prettier` is a JavaScript package, so you're going to need to install `node` to work with it
+* [`node`](https://nodejs.org/en/download/) `8.3` or newer - `prettier` is a JavaScript package, so you're going to need to install `node` to work with it
 * [`npm`](https://www.npmjs.com/get-npm) or [`yarn`](https://yarnpkg.com/en/docs/getting-started) - these are package managers for JavaScript, either one will do
 
 Second, you're going to need to list `prettier-plugin-ruby` as a JavaScript dependency from within whatever project on which you're working.

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   },
   "devDependencies": {
     "jest": "^24.0.0"
+  },
+  "engines": {
+    "node": ">=8.3.0"
   }
 }


### PR DESCRIPTION
I was running into the following syntax error:

```
~/project $ prettier --write helpers/custom_helpers.rb
/Users/meleyal/project/node_modules/prettier-plugin-ruby/src/nodes.js:5
  ...require("./nodes/alias"),
  ^^^

SyntaxError: Unexpected token ...
```

It took me a moment to realise it was the lack of object rest/spread in my node version (was using 6.x).