### PR TITLE
Command nodes within conditionals now break parents to disallow them …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Command nodes within conditionals now break parents to disallow them from being turned into ternary expressions. (Thanks to @bugthing for the report.)
 
 ## [0.3.2] - 2019-02-09
 ### Changed

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -284,10 +284,15 @@ module.exports = {
     concat(path.call(print, "body", 0)),
     "\""
   ]),
-  else: (path, opts, print) => concat([
-    "else",
-    indent(concat([softline, path.call(print, "body", 0)]))
-  ]),
+  else: (path, opts, print) => {
+    const stmts = path.getValue().body[0];
+
+    return concat([
+      stmts.body.length === 1 && stmts.body[0].type === "command" ? breakParent : "",
+      "else",
+      indent(concat([softline, path.call(print, "body", 0)]))
+    ]);
+  },
   elsif: (path, opts, print) => {
     const [_predicate, _statements, addition] = path.getValue().body;
     const parts = [

--- a/src/nodes/conditionals.js
+++ b/src/nodes/conditionals.js
@@ -14,7 +14,7 @@ const printTernaryConditions = (keyword, truthyValue, falsyValue) => {
 };
 
 const printConditional = keyword => (path, { inlineConditionals }, print) => {
-  const [_predicate, statements, addition] = path.getValue().body;
+  const [_predicate, stmts, addition] = path.getValue().body;
 
   // If the addition is not an elsif or an else, then it's the second half of a
   // ternary expression
@@ -42,10 +42,14 @@ const printConditional = keyword => (path, { inlineConditionals }, print) => {
     const truthyValue = path.call(print, "body", 1);
     const falsyValue = path.call(print, "body", 2, "body", 0);
 
+    if (stmts.body.length === 1 && stmts.body[0].type === "command") {
+      return printWithAddition(keyword, path, print);
+    }
+
     return group(ifBreak(
       printWithAddition(keyword, path, print),
       concat([
-        statements.body.every(({ type }) => ["void_stmt", "@comment"].includes(type)) ? breakParent : "",
+        stmts.body.every(({ type }) => ["void_stmt", "@comment"].includes(type)) ? breakParent : "",
         ...parts,
         ...printTernaryConditions(keyword, truthyValue, falsyValue)
       ])

--- a/test/__snapshots__/ruby.test.js.snap
+++ b/test/__snapshots__/ruby.test.js.snap
@@ -1134,6 +1134,18 @@ if a
 else
   super_super_super_super_super_super_super_super_super_super_super_super_long
 end
+
+if a
+  b 1
+else
+  b(2)
+end
+
+if a
+  b(1)
+else
+  b 2
+end
 "
 `;
 
@@ -1209,6 +1221,18 @@ if a
   super_super_super_super_super_super_super_super_super_super_super_long
 else
   super_super_super_super_super_super_super_super_super_super_super_super_long
+end
+
+if a
+  b 1
+else
+  b(2)
+end
+
+if a
+  b(1)
+else
+  b 2
 end
 "
 `;

--- a/test/if.rb
+++ b/test/if.rb
@@ -71,3 +71,15 @@ end
 a ? 1 : 2
 a ? super_super_super_super_super_super_super_super_super_super_super_long
   : super_super_super_super_super_super_super_super_super_super_super_super_long
+
+if a
+  b 1
+else
+  b(2)
+end
+
+if a
+  b(1)
+else
+  b 2
+end


### PR DESCRIPTION
…from being turned into ternary expressions.

Fixes #52