### PR TITLE
Properly escape double quotes when using `preferSingleQuotes: false`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [Unreleased]
 ### Changed
 - Command nodes within conditionals now break parents to disallow them from being turned into ternary expressions. (Thanks to @bugthing for the report.)
+- Properly escape double quotes when using `preferSingleQuotes: false`. (Thanks to @awinograd for the report.)
 
 ## [0.3.2] - 2019-02-09
 ### Changed

--- a/src/nodes/strings.js
+++ b/src/nodes/strings.js
@@ -1,6 +1,29 @@
 const { concat, group, hardline, indent, join, line, softline } = require("prettier").doc.builders;
 const { concatBody, empty, surround } = require("../utils");
 
+// Matches _any_ escape and unescaped quotes (both single and double).
+const quotePattern = /\\([\s\S])|(['"])/g;
+
+const makeString = (content, enclosingQuote) => {
+  const otherQuote = enclosingQuote === '"' ? "'" : '"';
+
+  // Escape and unescape single and double quotes as needed to be able to
+  // enclose `content` with `enclosingQuote`.
+  return content.replace(quotePattern, (match, escaped, quote) => {
+    if (escaped === otherQuote) {
+      return escaped;
+    }
+
+    if (quote === enclosingQuote) {
+      return "\\" + quote;
+    }
+
+    if (quote) {
+      return quote;
+    }
+  });
+};
+
 module.exports = {
   "@CHAR": (path, { preferSingleQuotes }, print) => {
     const { body } = path.getValue();
@@ -30,22 +53,40 @@ module.exports = {
   string_dvar: surround("#{", "}"),
   string_embexpr: surround("#{", "}"),
   string_literal: (path, { preferSingleQuotes }, print) => {
-    if (path.getValue().body[0].type === "heredoc") {
+    const string = path.getValue().body[0];
+
+    // If this string is actually a heredoc, bail out and return to the print
+    // function for heredocs
+    if (string.type === "heredoc") {
       return path.call(print, "body", 0);
     }
 
-    const parts = path.call(print, "body", 0);
-
-    if (parts === '') {
+    // If the string is empty, it will not have any parts, so just print out the
+    // quotes corresponding to the config
+    if (string.body.length === 0) {
       return preferSingleQuotes ? "''" : "\"\"";
     }
 
-    let delim = "\"";
-    if (preferSingleQuotes && !parts.some(part => part.parts ? part.parts[0] === "#{" : part.includes("'"))) {
-      delim = "\'";
+    // Determine the quote to use. If we prefer single quotes and there are no
+    // embedded expressions and there aren't any single quotes in the string
+    // already, we can safely switch to single quotes.
+    let quote = "\"";
+    if (preferSingleQuotes && string.body.every(part => part.type === "@tstring_content" && !part.body.includes("'"))) {
+      quote = "\'";
     }
 
-    return concat([delim, ...parts, delim]);
+    const parts = [];
+    string.body.forEach((part, index) => {
+      if (part.type === "@tstring_content") {
+        // In this case, the part of the string is just regular string content
+        parts.push(makeString(part.body, quote));
+      } else {
+        // In this case, the part of the string is an embedded expression
+        parts.push(path.call(print, "body", 0, "body", index));
+      }
+    });
+
+    return concat([quote, ...parts, quote]);
   },
   word_add: concatBody,
   word_new: empty,

--- a/src/ripper.rb
+++ b/src/ripper.rb
@@ -26,6 +26,8 @@ class RipperJS < Ripper::SexpBuilder
 
   def parse
     super.tap do |sexp|
+      next if block_comments.empty?
+
       sexp[:body][0][:body] = (block_comments + sexp.dig(:body, 0, :body)).sort_by { |node| node[:start] }
     end
   end

--- a/test/__snapshots__/ruby.test.js.snap
+++ b/test/__snapshots__/ruby.test.js.snap
@@ -1862,6 +1862,8 @@ PARENT
 #{\\"interpolated\\"}
 GRAND
 
+\\"abc \\\\\\"abc\\\\\\" abc\\"
+
 # rubocop:enable Lint/Void
 "
 `;
@@ -1954,6 +1956,8 @@ PARENT
 PARENT
 #{'interpolated'}
 GRAND
+
+'abc \\"abc\\" abc'
 
 # rubocop:enable Lint/Void
 "

--- a/test/strings.rb
+++ b/test/strings.rb
@@ -88,4 +88,6 @@ PARENT
 #{'interpolated'}
 GRAND
 
+'abc "abc" abc'
+
 # rubocop:enable Lint/Void


### PR DESCRIPTION
Fixes #53