### PR TITLE
Stop transforming multistatement blocks with to_proc

### DIFF
--- a/test/__snapshots__/ruby.test.js.snap
+++ b/test/__snapshots__/ruby.test.js.snap
@@ -330,6 +330,11 @@ loop(&:to_s)
 
 loop(&:to_s)
 
+loop do |i|
+  i.to_s
+  i.next
+end
+
 loop { |i| i.to_s :db }
 
 loop { |i, j| i.to_s }
@@ -391,6 +396,11 @@ loop { |i| super_super_super_super_super_super_super_super_super_super_long }
 loop(&:to_s)
 
 loop(&:to_s)
+
+loop do |i|
+  i.to_s
+  i.next
+end
 
 loop { |i| i.to_s :db }
 

--- a/test/blocks.rb
+++ b/test/blocks.rb
@@ -49,6 +49,11 @@ loop do |i|
 end
 
 loop do |i|
+  i.to_s
+  i.next
+end
+
+loop do |i|
   i.to_s :db
 end
 


### PR DESCRIPTION
Blocks with multiple statements where the first statement is a method call on the only argument to the block were being transformed with the `to_proc` shorthand, which caused all the other statements to be removed.

```ruby
loop do |i|
  i.to_s
  i.next
end
```

to

```ruby
loop(&:to_s)
```

This PR requires that the call be the only statement in the block for the transformation to be applied.