### PR TITLE
Specify as a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you do not already have a `package.json` file in the root of your repository,
 echo '{ "name": "My Project" }' > package.json
 ```
 
-After that you can add `prettier` and `@prettier/plugin-ruby` to your `package.json` `dependencies` by running `npm install prettier @prettier/plugin-ruby` if you are using `npm` or `yarn add prettier @prettier/plugin-ruby` if you are using `yarn`.
+After that you can add `prettier` and `@prettier/plugin-ruby` to your `package.json` `devDependencies` by running `npm install prettier @prettier/plugin-ruby --saveDev` if you are using `npm` or `yarn add prettier @prettier/plugin-ruby --dev` if you are using `yarn`.
 
 Finally, you can install your dependencies using either `npm install` for `npm` or `yarn install` for `yarn`.
 


### PR DESCRIPTION
Maybe I'm missing something, but I'd expect anything related to prettier should be a dev dependency only?