### PR TITLE
Support trailing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Below are the options (from [`src/ruby.js`](src/ruby.js)) that `@prettier/plugin
 | `inlineLoops` | `true` | When it fits on one line, allows while and until statements to use the modifier form. |
 | `preferHashLabels` | `true` | When possible, uses the shortened hash key syntax, as opposed to hash rockets. |
 | `preferSingleQuotes` | `true` | When double quotes are not necessary for interpolation, prefers the use of single quotes for string literals. |
+| `trailingComma` | `false` | Adds a trailing comma to array literals, hash literals, and method calls. |
 
 ## Development
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -55,7 +55,7 @@ module.exports = {
     const buffer = skipAssignIndent(rightArg) ? ", " : concat([",", line]);
     return join(buffer, path.map(print, "body"));
   },
-  args_add_block: (path, opts, print) => {
+  args_add_block: (path, { trailingComma }, print) => {
     const [args, block] = path.getValue().body;
     const parts = args.type === "args_new" ? [] : [path.call(print, "body", 0)];
 
@@ -66,7 +66,10 @@ module.exports = {
       parts.push(concat(["&", path.call(print, "body", 1)]));
     }
 
-    return group(concat(parts));
+    return group(concat([
+      ...parts,
+      trailingComma ? ifBreak(",", "") : ""
+    ]));
   },
   args_add_star: (path, opts, print) => {
     if (path.getValue().body[0].type === "args_new") {
@@ -141,7 +144,9 @@ module.exports = {
   assign_error: (path, opts, print) => {
     throw new Error("Can't set variable");
   },
-  bare_assoc_hash: (path, opts, print) => group(join(concat([",", line]), path.map(print, "body", 0))),
+  bare_assoc_hash: (path, opts, print) => group(
+    join(concat([",", line]), path.map(print, "body", 0))
+  ),
   begin: (path, opts, print) => group(concat([
     "begin",
     indent(concat([hardline, concat(path.map(print, "body"))])),
@@ -318,14 +323,18 @@ module.exports = {
     path.call(print, "body", 0),
     concat([makeCall(path, opts, print), path.call(print, "body", 2)])
   ])),
-  hash: (path, opts, print) => {
+  hash: (path, { trailingComma }, print) => {
     if (path.getValue().body[0] === null) {
       return '{}';
     }
 
     return group(concat([
       "{",
-      indent(concat([line, concat(path.map(print, "body"))])),
+      indent(concat([
+        line,
+        concat(path.map(print, "body")),
+        trailingComma ? ifBreak(",", "") : "",
+      ])),
       concat([line, "}"])
     ]));
   },

--- a/src/nodes/arrays.js
+++ b/src/nodes/arrays.js
@@ -1,9 +1,9 @@
-const { concat, group, indent, join, line, softline } = require("prettier").doc.builders;
+const { concat, group, ifBreak, indent, join, line, softline } = require("prettier").doc.builders;
 
 const makeArray = start => (path, opts, print) => [start, ...path.map(print, "body")];
 
 module.exports = {
-  array: (path, opts, print) => {
+  array: (path, { trailingComma }, print) => {
     if (path.getValue().body[0] === null) {
       return '[]';
     }
@@ -11,7 +11,11 @@ module.exports = {
     if (["args_add", "args_add_star"].includes(path.getValue().body[0].type)) {
       return group(concat([
         "[",
-        indent(concat([softline, path.call(print, "body", 0)])),
+        indent(concat([
+          softline,
+          path.call(print, "body", 0),
+          trailingComma ? ifBreak(",", "") : ""
+        ])),
         concat([softline, "]"])
       ]));
     }

--- a/src/ruby.js
+++ b/src/ruby.js
@@ -25,25 +25,31 @@ module.exports = {
       type: "boolean",
       category: "Global",
       default: true,
-      description: "When it fits on one line, allow if and unless statements to use the modifier form."
+      description: "When it fits on one line, allows if and unless statements to use the modifier form."
     },
     inlineLoops: {
       type: "boolean",
       category: "Global",
       default: true,
-      description: "When it fits on one line, allow while and until statements to use the modifier form."
+      description: "When it fits on one line, allows while and until statements to use the modifier form."
     },
     preferHashLabels: {
       type: "boolean",
       category: "Global",
       default: true,
-      description: "When possible, use the shortened hash key syntax, as opposed to hash rockets."
+      description: "When possible, uses the shortened hash key syntax, as opposed to hash rockets."
     },
     preferSingleQuotes: {
       type: "boolean",
       category: "Global",
       default: true,
-      description: "When double quotes are not necessary for interpolation, prefer the use of single quotes for string literals."
+      description: "When double quotes are not necessary for interpolation, prefers the use of single quotes for string literals."
+    },
+    trailingComma: {
+      type: "boolean",
+      category: "Global",
+      default: false,
+      description: "Adds a trailing comma to array literals, hash literals, and method calls."
     }
   },
   defaultOptions: {

--- a/test/__snapshots__/ruby.test.js.snap
+++ b/test/__snapshots__/ruby.test.js.snap
@@ -98,8 +98,8 @@ exports[`array.rb matches expected output for on.json 1`] = `
   super_super_super_super_super_super_super_super_super_super_super_long,
   super_super_super_super_super_super_super_super_super_super_super_long, [
     super_super_super_super_super_super_super_super_super_super_super_long,
-    super_super_super_super_super_super_super_super_super_super_super_long
-  ]
+    super_super_super_super_super_super_super_super_super_super_super_long,
+  ],
 ]
 
 a[1]
@@ -117,7 +117,7 @@ a[
 
 a[1] = [
   super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long
+  super_super_super_super_super_super_super_super_super_super_super_long,
 ]
 
 # rubocop:enable Lint/Void
@@ -243,13 +243,13 @@ a ||=
 a = [
   super_super_super_super_super_super_super_super_super_super_super_long,
   super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long
+  super_super_super_super_super_super_super_super_super_super_super_long,
 ]
 
 a = {
   a: super_super_super_super_super_super_super_super_super_super_long,
   b: super_super_super_super_super_super_super_super_super_super_long,
-  c: super_super_super_super_super_super_super_super_super_super_long
+  c: super_super_super_super_super_super_super_super_super_super_long,
 }
 
 a = [super_super_super_super_long, super_super_super_super_long].sort
@@ -824,7 +824,7 @@ bar # this is another inline comment
   # inside of an array
   foo,
   # inside of an array
-  bar
+  bar,
 ]
 
 {
@@ -833,7 +833,7 @@ bar # this is another inline comment
     'bar',
   bar:
     # inside of a hash
-    'baz'
+    'baz',
 }
 
 foo # inline comment inside of a dot
@@ -1038,8 +1038,8 @@ exports[`hash.rb matches expected output for on.json 1`] = `
     super_super_super_super_super_super_super_super_long,
   super_super_super_super_super_super_super_super_super_long: {
     super_super_super_super_super_super_super_super_long:
-      super_super_super_super_super_super_super_super_long
-  }
+      super_super_super_super_super_super_super_super_long,
+  },
 }
 
 foo abc: true # some comment
@@ -1049,14 +1049,14 @@ foobar alpha: alpha,
        gamma: gamma,
        delta: delta,
        epsilon: epsilon,
-       zeta: zeta
+       zeta: zeta,
 foobar(
   alpha: alpha,
   beta: beta,
   gamma: gamma,
   delta: delta,
   epsilon: epsilon,
-  zeta: zeta
+  zeta: zeta,
 )
 
 # rubocop:enable Lint/Void
@@ -1498,6 +1498,17 @@ foo(1)
 foo(1, 2)
 foo(1, 2, *abc)
 foo(1, 2, *abc, 3, 4)
+foo(
+  aaaaaaa,
+  bbbbbbb,
+  ccccccc,
+  ddddddd,
+  eeeeeee,
+  fffffff,
+  ggggggg,
+  hhhhhhh,
+  iiiiiii
+)
 
 foo(*bar)
 foo(**baz)
@@ -1562,6 +1573,17 @@ foo(1)
 foo(1, 2)
 foo(1, 2, *abc)
 foo(1, 2, *abc, 3, 4)
+foo(
+  aaaaaaa,
+  bbbbbbb,
+  ccccccc,
+  ddddddd,
+  eeeeeee,
+  fffffff,
+  ggggggg,
+  hhhhhhh,
+  iiiiiii,
+)
 
 foo(*bar)
 foo(**baz)

--- a/test/config/off.json
+++ b/test/config/off.json
@@ -2,5 +2,6 @@
   "inlineConditionals": false,
   "inlineLoops": false,
   "preferHashLabels": false,
-  "preferSingleQuotes": false
+  "preferSingleQuotes": false,
+  "trailingComma": false
 }

--- a/test/config/on.json
+++ b/test/config/on.json
@@ -2,5 +2,6 @@
   "inlineConditionals": true,
   "inlineLoops": true,
   "preferHashLabels": true,
-  "preferSingleQuotes": true
+  "preferSingleQuotes": true,
+  "trailingComma": true
 }

--- a/test/config/on.yml
+++ b/test/config/on.yml
@@ -1,2 +1,11 @@
 Style/Documentation:
   Enabled: false
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma

--- a/test/method.rb
+++ b/test/method.rb
@@ -42,6 +42,7 @@ foo(1)
 foo(1, 2)
 foo(1, 2, *abc)
 foo(1, 2, *abc, 3, 4)
+foo(aaaaaaa, bbbbbbb, ccccccc, ddddddd, eeeeeee, fffffff, ggggggg, hhhhhhh, iiiiiii)
 
 foo(*bar)
 foo(**baz)


### PR DESCRIPTION
Adds a trailingComma configuration option that defaults to false. When true, adds trailing commas to broken groups of method invocations, hash literals, and array literals.

Closes #67