### PR TITLE
Return modified string from String.prototype.replace

### DIFF
--- a/src/nodes/strings.js
+++ b/src/nodes/strings.js
@@ -9,7 +9,7 @@ const makeString = (content, enclosingQuote) => {
 
   // Escape and unescape single and double quotes as needed to be able to
   // enclose `content` with `enclosingQuote`.
-  content.replace(quotePattern, (match, escaped, quote) => {
+  return content.replace(quotePattern, (match, escaped, quote) => {
     if (escaped === otherQuote) {
       return escaped;
     }
@@ -22,8 +22,6 @@ const makeString = (content, enclosingQuote) => {
       return quote;
     }
   });
-
-  return content;
 };
 
 module.exports = {


### PR DESCRIPTION
String.prototype.replace does not mutate the string it is called on.

Bug introduced in 2eaaa3227cefa0ac258eb5e0a65987f3dfa8dd10