### PR TITLE
[WIP] Fix handling of block args with trailing commas

### DIFF
--- a/test/__snapshots__/ruby.test.js.snap
+++ b/test/__snapshots__/ruby.test.js.snap
@@ -400,6 +400,10 @@ assert_nil(
   )
 )
 
+list_of_things_that_is_long_and_will_cause_a_line_break.select(:foo).reject(
+  &:blank?
+)
+
 # rubocop:enable Lint/UnusedBlockArgument
 "
 `;
@@ -495,6 +499,10 @@ assert_nil(
     end&.foo do
     end
   ),
+)
+
+list_of_things_that_is_long_and_will_cause_a_line_break.select(:foo).reject(
+  &:blank?
 )
 
 # rubocop:enable Lint/UnusedBlockArgument

--- a/test/blocks.rb
+++ b/test/blocks.rb
@@ -98,4 +98,6 @@ end
 # from ruby test/ruby/test_call.rb
 assert_nil(("a".sub! "b" do end&.foo {}))
 
+list_of_things_that_is_long_and_will_cause_a_line_break.select(:foo).reject(&:blank?)
+
 # rubocop:enable Lint/UnusedBlockArgument


### PR DESCRIPTION
This change adds support for block arguments being passed to methods
when the trailing commas functionality is enabled. Other argument types
to methods are fine with a trailing comma, but trailing commas after
block arguments, e.g. `&:blank?`, are not allowed.

-------

This PR currently only contains a failing test that demonstrates the issue.
Note, I manually edited the snapshot to contain the expected output, and
I'm relying on the Rubocop failure to highlight the issue here.

I believe the fix would need to be implemented here: 

https://github.com/prettier/plugin-ruby/blob/5dd827a8014cd9bc3a7a604e4f730aae1b2f933d/src/nodes.js#L29

likely checking the type of the current node and conditionally overriding
the trailiing commas setting in this case, but I'm unsure how to check on that.
Happy to tackle the fix if you can provide any pointers.

Also, I just wanted to say how excited I am to see the work on this! The lack
of a formatter is one of the things I miss most when switching back to ruby
from JS and other ecosystems.