### PR TITLE
Align print and sexp api

### DIFF
--- a/bin/print
+++ b/bin/print
@@ -2,7 +2,19 @@
 
 const fs = require("fs");
 const prettier = require("prettier");
-const print = require("../src/print");
 
-const code = process.argv.slice(1).join(" ");
+const isFile = function(path) {
+  try {
+    return fs.statSync(path).isFile();
+  } catch (err) {
+    return false;
+  }
+};
+
+const code = isFile(process.argv[2])
+  ? fs.readFileSync(process.argv[2], "utf-8")
+  : process.argv
+      .slice(2)
+      .join(" ")
+      .replace(/\\n/g, "\n");
 console.log(prettier.format(code, { parser: "ruby", plugins: ["."] }));


### PR DESCRIPTION
Updating `bin/print` to take a file path or Ruby input, aligning with the current `bin/sexp` API

```ruby
$ ./bin/print foo.txt
1 + 2 + 3

```

```ruby
./bin/print 1 + 2 + 3
1 + 2 + 3

```