### PR TITLE
Fix the handling of invalid ruby

### DIFF
--- a/src/ripper.rb
+++ b/src/ripper.rb
@@ -371,9 +371,10 @@ class RipperJS < Ripper::SexpBuilder
 end
 
 if $0 == __FILE__
-  response = RipperJS.new($stdin.read).parse
+  builder = RipperJS.new($stdin.read)
+  response = builder.parse
 
-  if response.nil?
+  if builder.error?
     STDERR.puts 'Invalid ruby'
     exit 1
   end

--- a/test/ruby.test.js
+++ b/test/ruby.test.js
@@ -155,7 +155,7 @@ eachConfig((prettierConfig, rubocopConfig, config) => {
 
     eachError(config, (file, getContents) => {
       test(`${file} throws error on parsing`, () => {
-        expect(getContents).toThrowError();
+        expect(getContents).toThrowError('Invalid ruby');
       });
     });
   });


### PR DESCRIPTION
Noticed a weird bug when playing around with the Ruby prettier playground:

![image](https://user-images.githubusercontent.com/1271782/53213288-42eac600-3640-11e9-8120-1831fb7497ff.png)

Poked around for a bit and found out the Ruby code wasn't valid because of the trailing comma:

> (irb):6: syntax error, unexpected end, expecting end-of-input

This PR should hopefully catch invalid Ruby source code now 🤞 