### PR TITLE
Add minitest for array.rb

### DIFF
--- a/test/__snapshots__/ruby.test.js.snap
+++ b/test/__snapshots__/ruby.test.js.snap
@@ -31,65 +31,100 @@ end
 exports[`for the off.json config array.rb matches expected output 1`] = `
 "# frozen_string_literal: true
 
-# rubocop:disable Lint/Void
+# rubocop:disable Metrics/LineLength
+# rubocop:disable Metrics/MethodLength
 
-[]
+class ArrayTest < Minitest::Test
+  def test_array
+    assert_equal_join \\"\\", []
+    assert_equal_join \\"1, 2, 3\\", [1, 2, 3]
+    assert_equal_join \\"a, b, c\\", %w[a b c]
+    assert_equal_join \\"a, b c, d\\", [\\"a\\", \\"b c\\", \\"d\\"]
+    assert_equal_join \\"a, b, c\\", %i[a b c]
+    assert_equal_join \\"a, b c, d\\", [:a, :\\"b c\\", :d]
+  end
 
-[1, 2, 3]
+  def test_array_with_general_delimited_syntax
+    foo = \\"foo\\"
+    bar = \\"bar\\"
+    baz = \\"baz\\"
+    assert_equal_join \\"a, b, c\\", %w[a b c]
+    assert_equal_join \\"a, b, c\\", %i[a b c]
+    assert_equal_join \\"afooa, bbarb, cbazc\\", %W[a#{foo}a b#{bar}b c#{baz}c]
+    assert_equal_join \\"afooa, bbarb, cbazc\\", %I[a#{foo}a b#{bar}b c#{baz}c]
+  end
 
-%w[a b c]
+  def test_array_with_splat_operator
+    # rubocop:disable Lint/UnneededSplatExpansion
+    assert_equal_join \\"1, 2, 3, 4, 5, 6\\", [1, 2, *[3, 4], 5, 6]
+    # rubocop:enable Lint/UnneededSplatExpansion
+  end
 
-[\\"a\\", \\"b c\\", \\"d\\"]
+  def test_array_with_long_elements
+    super_super_super_super_super_super_super_super_super_super_super_long =
+      \\"foo\\"
+    assert_equal_join(
+      \\"foo, foo, foo, foo\\",
+      [
+        super_super_super_super_super_super_super_super_super_super_super_long,
+        super_super_super_super_super_super_super_super_super_super_super_long,
+        [
+          super_super_super_super_super_super_super_super_super_super_super_long,
+          super_super_super_super_super_super_super_super_super_super_super_long
+        ]
+      ]
+    )
+  end
 
-%i[a b c]
+  def test_array_assignment
+    a = %w[foo bar]
 
-[:a, :\\"b c\\", :d]
+    assert_equal_to_s \\"bar\\", a[1]
 
-%w[a b c]
+    a[1] = \\"baz\\"
 
-%i[a b c]
+    assert_equal_to_s \\"baz\\", a[1]
 
-%W[a#{a}a b#{b}a c#{c}c]
+    super_super_super_super_super_super_super_super_super_super_super_super_long_zero =
+      0
+    super_super_super_super_super_super_super_super_super_super_super_super_long_baz =
+      \\"baz\\"
 
-%I[a#{a}a b#{b}b c#{c}c]
+    assert_equal_to_s(
+      \\"foo\\",
+      a[
+        super_super_super_super_super_super_super_super_super_super_super_super_long_zero
+      ]
+    )
 
-# rubocop:disable Lint/UnneededSplatExpansion
-[1, 2, *[3, 4], 5, 6]
-# rubocop:enable Lint/UnneededSplatExpansion
+    a[1] = [
+      super_super_super_super_super_super_super_super_super_super_super_super_long_baz,
+      super_super_super_super_super_super_super_super_super_super_super_super_long_baz
+    ]
 
-[
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  [
-    super_super_super_super_super_super_super_super_super_super_super_long,
-    super_super_super_super_super_super_super_super_super_super_super_long
-  ]
-]
+    assert_equal_join \\"baz, baz\\", a[1]
 
-a[1]
+    a[1] = [
+      # abc
+      %w[abc]
+    ]
 
-a[
-  super_super_super_super_super_super_super_super_super_super_super_super_sulong
-]
+    assert_equal_join \\"abc\\", a[1]
+  end
 
-a[1] = 2
+  private
 
-a[
-  super_super_super_super_super_super_super_super_super_super_super_super_sulong
-] =
-  super_super_super_super_super_super_super_super_super_super_super_super_long
+  def assert_equal_join(expected, object)
+    assert_equal expected, object.join(\\", \\")
+  end
 
-a[1] = [
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long
-]
+  def assert_equal_to_s(expected, object)
+    assert_equal expected, object.to_s
+  end
+end
 
-a[1] = [
-  # abc
-  %w[abc]
-]
-
-# rubocop:enable Lint/Void
+# rubocop:enable Metrics/LineLength
+# rubocop:enable Metrics/MethodLength
 "
 `;
 
@@ -1520,65 +1555,100 @@ end
 exports[`for the on.json config array.rb matches expected output 1`] = `
 "# frozen_string_literal: true
 
-# rubocop:disable Lint/Void
+# rubocop:disable Metrics/LineLength
+# rubocop:disable Metrics/MethodLength
 
-[]
+class ArrayTest < Minitest::Test
+  def test_array
+    assert_equal_join '', []
+    assert_equal_join '1, 2, 3', [1, 2, 3]
+    assert_equal_join 'a, b, c', %w[a b c]
+    assert_equal_join 'a, b c, d', ['a', 'b c', 'd']
+    assert_equal_join 'a, b, c', %i[a b c]
+    assert_equal_join 'a, b c, d', [:a, :\\"b c\\", :d]
+  end
 
-[1, 2, 3]
+  def test_array_with_general_delimited_syntax
+    foo = 'foo'
+    bar = 'bar'
+    baz = 'baz'
+    assert_equal_join 'a, b, c', %w[a b c]
+    assert_equal_join 'a, b, c', %i[a b c]
+    assert_equal_join 'afooa, bbarb, cbazc', %W[a#{foo}a b#{bar}b c#{baz}c]
+    assert_equal_join 'afooa, bbarb, cbazc', %I[a#{foo}a b#{bar}b c#{baz}c]
+  end
 
-%w[a b c]
+  def test_array_with_splat_operator
+    # rubocop:disable Lint/UnneededSplatExpansion
+    assert_equal_join '1, 2, 3, 4, 5, 6', [1, 2, *[3, 4], 5, 6]
+    # rubocop:enable Lint/UnneededSplatExpansion
+  end
 
-['a', 'b c', 'd']
+  def test_array_with_long_elements
+    super_super_super_super_super_super_super_super_super_super_super_long =
+      'foo'
+    assert_equal_join(
+      'foo, foo, foo, foo',
+      [
+        super_super_super_super_super_super_super_super_super_super_super_long,
+        super_super_super_super_super_super_super_super_super_super_super_long,
+        [
+          super_super_super_super_super_super_super_super_super_super_super_long,
+          super_super_super_super_super_super_super_super_super_super_super_long,
+        ],
+      ],
+    )
+  end
 
-%i[a b c]
+  def test_array_assignment
+    a = %w[foo bar]
 
-[:a, :\\"b c\\", :d]
+    assert_equal_to_s 'bar', a[1]
 
-%w[a b c]
+    a[1] = 'baz'
 
-%i[a b c]
+    assert_equal_to_s 'baz', a[1]
 
-%W[a#{a}a b#{b}a c#{c}c]
+    super_super_super_super_super_super_super_super_super_super_super_super_long_zero =
+      0
+    super_super_super_super_super_super_super_super_super_super_super_super_long_baz =
+      'baz'
 
-%I[a#{a}a b#{b}b c#{c}c]
+    assert_equal_to_s(
+      'foo',
+      a[
+        super_super_super_super_super_super_super_super_super_super_super_super_long_zero
+      ],
+    )
 
-# rubocop:disable Lint/UnneededSplatExpansion
-[1, 2, *[3, 4], 5, 6]
-# rubocop:enable Lint/UnneededSplatExpansion
+    a[1] = [
+      super_super_super_super_super_super_super_super_super_super_super_super_long_baz,
+      super_super_super_super_super_super_super_super_super_super_super_super_long_baz,
+    ]
 
-[
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  [
-    super_super_super_super_super_super_super_super_super_super_super_long,
-    super_super_super_super_super_super_super_super_super_super_super_long,
-  ],
-]
+    assert_equal_join 'baz, baz', a[1]
 
-a[1]
+    a[1] = [
+      # abc
+      %w[abc],
+    ]
 
-a[
-  super_super_super_super_super_super_super_super_super_super_super_super_sulong
-]
+    assert_equal_join 'abc', a[1]
+  end
 
-a[1] = 2
+  private
 
-a[
-  super_super_super_super_super_super_super_super_super_super_super_super_sulong
-] =
-  super_super_super_super_super_super_super_super_super_super_super_super_long
+  def assert_equal_join(expected, object)
+    assert_equal expected, object.join(', ')
+  end
 
-a[1] = [
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long,
-]
+  def assert_equal_to_s(expected, object)
+    assert_equal expected, object.to_s
+  end
+end
 
-a[1] = [
-  # abc
-  %w[abc],
-]
-
-# rubocop:enable Lint/Void
+# rubocop:enable Metrics/LineLength
+# rubocop:enable Metrics/MethodLength
 "
 `;
 

--- a/test/cases/array.rb
+++ b/test/cases/array.rb
@@ -1,56 +1,91 @@
 # frozen_string_literal: true
 
-# rubocop:disable Lint/Void
+# rubocop:disable Metrics/LineLength
+# rubocop:disable Metrics/MethodLength
 
-[]
+class ArrayTest < Minitest::Test
+  def test_array
+    assert_equal_join "", []
+    assert_equal_join "1, 2, 3", [1, 2, 3]
+    assert_equal_join "a, b, c", ['a', 'b', 'c']
+    assert_equal_join "a, b c, d", ['a', 'b c', 'd']
+    assert_equal_join "a, b, c", [:a, :b, :c]
+    assert_equal_join "a, b c, d", [:a, :"b c", :d]
+  end
 
-[1, 2, 3]
+  def test_array_with_general_delimited_syntax
+    foo = 'foo'
+    bar = 'bar'
+    baz = 'baz'
+    assert_equal_join "a, b, c", %w[a b c]
+    assert_equal_join "a, b, c", %i[a b c]
+    assert_equal_join "afooa, bbarb, cbazc", %W[a#{foo}a b#{bar}b c#{baz}c]
+    assert_equal_join "afooa, bbarb, cbazc", %I[a#{foo}a b#{bar}b c#{baz}c]
+  end
 
-['a', 'b', 'c']
+  def test_array_with_splat_operator
+    # rubocop:disable Lint/UnneededSplatExpansion
+    assert_equal_join "1, 2, 3, 4, 5, 6", [1, 2, *[3, 4], 5, 6]
+    # rubocop:enable Lint/UnneededSplatExpansion
+  end
 
-['a', 'b c', 'd']
+  def test_array_with_long_elements
+    super_super_super_super_super_super_super_super_super_super_super_long =
+      'foo'
+    assert_equal_join(
+      "foo, foo, foo, foo",
+      [
+        super_super_super_super_super_super_super_super_super_super_super_long,
+        super_super_super_super_super_super_super_super_super_super_super_long, [
+          super_super_super_super_super_super_super_super_super_super_super_long,
+          super_super_super_super_super_super_super_super_super_super_super_long
+        ]
+      ]
+    )
+  end
 
-[:a, :b, :c]
+  def test_array_assignment
+    a = ["foo", "bar"]
 
-[:a, :"b c", :d]
+    assert_equal_to_s "bar", a[1]
 
-%w[a b c]
+    a[1] = "baz"
 
-%i[a b c]
+    assert_equal_to_s "baz", a[1]
 
-%W[a#{a}a b#{b}a c#{c}c]
+    super_super_super_super_super_super_super_super_super_super_super_super_long_zero = 0
+    super_super_super_super_super_super_super_super_super_super_super_super_long_baz = 'baz'
 
-%I[a#{a}a b#{b}b c#{c}c]
+    assert_equal_to_s(
+      "foo",
+      a[super_super_super_super_super_super_super_super_super_super_super_super_long_zero]
+    )
 
-# rubocop:disable Lint/UnneededSplatExpansion
-[1, 2, *[3, 4], 5, 6]
-# rubocop:enable Lint/UnneededSplatExpansion
+    a[1] = [
+      super_super_super_super_super_super_super_super_super_super_super_super_long_baz,
+      super_super_super_super_super_super_super_super_super_super_super_super_long_baz
+    ]
 
-[
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long, [
-    super_super_super_super_super_super_super_super_super_super_super_long,
-    super_super_super_super_super_super_super_super_super_super_super_long
-  ]
-]
+    assert_equal_join "baz, baz", a[1]
 
-a[1]
+    a[1] = [
+      # abc
+      %w[abc]
+    ]
 
-a[super_super_super_super_super_super_super_super_super_super_super_super_sulong]
+    assert_equal_join "abc", a[1]
+  end
 
-a[1] = 2
+  private
 
-a[super_super_super_super_super_super_super_super_super_super_super_super_sulong] =
-  super_super_super_super_super_super_super_super_super_super_super_super_long
+  def assert_equal_join(expected, object)
+    assert_equal expected, object.join(', ')
+  end
 
-a[1] = [
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long
-]
+  def assert_equal_to_s(expected, object)
+    assert_equal expected, object.to_s
+  end
+end
 
-a[1] = [
-  # abc
-  %w[abc]
-]
-
-# rubocop:enable Lint/Void
+# rubocop:enable Metrics/LineLength
+# rubocop:enable Metrics/MethodLength

--- a/test/ruby.test.js
+++ b/test/ruby.test.js
@@ -11,6 +11,7 @@ const escapePattern = require("../src/escapePattern");
 
 const expectedMinitestFiles = [
   "alias.rb",
+  "array.rb",
   "binary.rb",
   "next.rb",
   "numbers.rb",


### PR DESCRIPTION
Why:
We would like for the array.rb file for the test snapshots to also be a
minitest test so that we can run the ruby tests after the prettier
formatting process an validate that arrays are syntactically correct
post formatting.

this commit:
Introduces minitest to '/test/cases/array.rb'

issue: [#120](https://github.com/prettier/plugin-ruby/issues/120)