### PR TITLE
Improve layout for access modifiers

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1,6 +1,6 @@
 const { align, breakParent, concat, dedent, dedentToRoot, group, hardline, ifBreak, indent, join, line, lineSuffix, literalline, markAsRoot, softline, trim } = require("prettier").doc.builders;
 const { removeLines } = require("prettier").doc.utils;
-const { concatBody, docLength, empty, first, literal, makeCall, makeList, prefix, printComments, skipAssignIndent, isVCallAccessModifier } = require("./utils");
+const { concatBody, docLength, empty, first, literal, makeCall, makeList, paren, prefix, printComments, skipAssignIndent, isVCallAccessModifier } = require("./utils")
 
 module.exports = {
   ...require("./nodes/alias"),
@@ -250,7 +250,7 @@ module.exports = {
       ifBreak(
         hasDefArgs(path.getNode())
           ? concat([command, " ", args])
-          : concat([command, " ", align(command.length + 1, args)]),
+          : concat([command, " ", align(docLength(command) + 1, args)]),
         concat([command, " ", args])
       )
     );
@@ -480,11 +480,7 @@ module.exports = {
       content = join(concat([",", line]), content);
     }
 
-    return group(concat([
-      "(",
-      indent(concat([softline, content])),
-      concat([softline, ")"])
-    ]));
+    return paren(content);
   },
   program: (path, opts, print) => markAsRoot(concat([
     join(literalline, path.map(print, "body")),

--- a/src/nodes/methods.js
+++ b/src/nodes/methods.js
@@ -1,4 +1,5 @@
 const { concat, group, hardline, indent } = require("prettier").doc.builders;
+const { paren } = require("../utils")
 
 const printMethod = offset => (path, opts, print) => {
   const [name, params, body] = path.getValue().body.slice(offset);
@@ -12,12 +13,10 @@ const printMethod = offset => (path, opts, print) => {
 
   // In case there are no parens but there are arguments
   const parens = params.type === "params" && params.body.some(paramType => paramType);
-
+  const content = path.call(print, "body", offset + 1);
   declaration.push(
     path.call(print, "body", offset),
-    parens ? "(" : "",
-    path.call(print, "body", offset + 1),
-    parens ? ")" : ""
+    parens ? paren(content) : content
   );
 
   // If the body is empty, we can replace with a ;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-const { breakParent, concat, hardline, lineSuffix } = require("prettier").doc.builders;
+const { breakParent, concat, group, hardline, indent, lineSuffix, softline } = require("prettier").doc.builders;
 
 const concatBody = (path, opts, print) => concat(path.map(print, "body"));
 
@@ -41,6 +41,12 @@ const prefix = value => (path, opts, print) => concat([
   value,
   path.call(print, "body", 0)
 ]);
+
+const paren = (content) => group(concat([
+  "(",
+  indent(concat([softline, content])),
+  concat([softline, ")"])
+]));
 
 const printComments = (printed, start, comments) => {
   let node = printed;
@@ -86,6 +92,7 @@ module.exports = {
   literal,
   makeCall,
   makeList,
+  paren,
   prefix,
   printComments,
   skipAssignIndent,

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,9 +2,26 @@ const { breakParent, concat, hardline, lineSuffix } = require("prettier").doc.bu
 
 const concatBody = (path, opts, print) => concat(path.map(print, "body"));
 
+const docLength = function (doc) {
+  if (doc.length) {
+    return doc.length;
+  }
+
+  if (doc.parts) {
+    return doc.parts.reduce((sum, doc) => sum + docLength(doc), 0);
+  };
+
+  return 0;
+}
+
 const empty = () => "";
 
 const first = (path, opts, print) => path.call(print, "body", 0);
+
+const isVCallAccessModifier = node =>
+  node.type === 'vcall' &&
+  node.body[0].type === "@ident" &&
+  ["private", "public", "protected"].includes(node.body[0].body);
 
 const literal = value => () => value;
 
@@ -62,8 +79,10 @@ const surround = (left, right) => (path, opts, print) => concat([
 
 module.exports = {
   concatBody,
+  docLength,
   empty,
   first,
+  isVCallAccessModifier,
   literal,
   makeCall,
   makeList,

--- a/test/cases/access_modifiers/__snapshots__/jsfmt.spec.js.snap
+++ b/test/cases/access_modifiers/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`for the off.json config access_modifiers.rb matches expected output 1`] = `
+"# frozen_string_literal: true
+
+# rubocop:disable Lint/UnusedMethodArgument
+# rubocop:disable Lint/UselessAccessModifier
+# rubocop:disable Style/AccessModifierDeclarations
+
+class AccessModifiersTest < Minitest::Test
+  def test_simple_modifiers
+    instance = SimpleModifiers.new
+
+    assert_includes instance.public_methods, :public_foo
+    assert_includes instance.protected_methods, :protected_foo
+    assert_includes instance.protected_methods, :protected_bar
+    assert_includes instance.private_methods, :private_foo
+  end
+
+  def test_complex_modifiers
+    instance = ComplexCommandModifiers.new
+
+    assert_includes instance.public_methods, :public_custom_method_helper_prefix
+    assert_includes instance.public_methods, :public_foo
+    assert_includes instance.protected_methods,
+                    :protected_custom_method_helper_prefix
+    assert_includes instance.protected_methods, :protected_foo
+    assert_includes instance.private_methods, :private_foo
+  end
+
+  private
+
+  class SimpleModifiers
+    public
+
+    def public_foo(); end
+
+    protected
+
+    def protected_foo(); end
+
+    # testing
+
+    protected # testing
+
+    # testing
+    def protected_bar(); end
+
+    private
+
+    def private_foo(); end
+  end
+
+  class ComplexCommandModifiers
+    def self.custom_method_helper(method_name)
+      method_name
+    end
+
+    custom_method_helper def public_custom_method_helper_prefix(arg)
+      true
+    end
+
+    public def public_foo(arg)
+      true
+    end
+
+    protected custom_method_helper def protected_custom_method_helper_prefix(
+      arg
+    )
+      true
+    end
+
+    private def private_foo(
+      _alpha: \\"foobar\\",
+      _beta: \\"foobar\\",
+      _gamma: \\"foobar\\",
+      _delta: \\"foobar\\",
+      _zeta: \\"foobar\\"
+    )
+      true
+    end
+
+    # rubocop:disable all
+    protected def protected_foo(_alpha: \\"foobar\\",
+    _beta: \\"foobar\\",
+    _gamma: \\"foobar\\",
+    _delta: \\"foobar\\",
+    _zeta: \\"foobar\\")
+      true
+    end
+    # rubocop:enable all
+  end
+end
+
+# rubocop:enable Lint/UnusedMethodArgument
+# rubocop:enable Lint/UselessAccessModifier
+# rubocop:enable Style/AccessModifierDeclarations
+"
+`;
+
+exports[`for the on.json config access_modifiers.rb matches expected output 1`] = `
+"# frozen_string_literal: true
+
+# rubocop:disable Lint/UnusedMethodArgument
+# rubocop:disable Lint/UselessAccessModifier
+# rubocop:disable Style/AccessModifierDeclarations
+
+class AccessModifiersTest < Minitest::Test
+  def test_simple_modifiers
+    instance = SimpleModifiers.new
+
+    assert_includes instance.public_methods, :public_foo
+    assert_includes instance.protected_methods, :protected_foo
+    assert_includes instance.protected_methods, :protected_bar
+    assert_includes instance.private_methods, :private_foo
+  end
+
+  def test_complex_modifiers
+    instance = ComplexCommandModifiers.new
+
+    assert_includes instance.public_methods, :public_custom_method_helper_prefix
+    assert_includes instance.public_methods, :public_foo
+    assert_includes instance.protected_methods,
+                    :protected_custom_method_helper_prefix
+    assert_includes instance.protected_methods, :protected_foo
+    assert_includes instance.private_methods, :private_foo
+  end
+
+  private
+
+  class SimpleModifiers
+    public
+
+    def public_foo(); end
+
+    protected
+
+    def protected_foo(); end
+
+    # testing
+
+    protected # testing
+
+    # testing
+    def protected_bar(); end
+
+    private
+
+    def private_foo(); end
+  end
+
+  class ComplexCommandModifiers
+    def self.custom_method_helper(method_name)
+      method_name
+    end
+
+    custom_method_helper def public_custom_method_helper_prefix(arg)
+      true
+    end
+
+    public def public_foo(arg)
+      true
+    end
+
+    protected custom_method_helper def protected_custom_method_helper_prefix(
+      arg
+    )
+      true
+    end
+
+    private def private_foo(
+      _alpha: 'foobar',
+      _beta: 'foobar',
+      _gamma: 'foobar',
+      _delta: 'foobar',
+      _zeta: 'foobar'
+    )
+      true
+    end
+
+    # rubocop:disable all
+    protected def protected_foo(_alpha: 'foobar',
+    _beta: 'foobar',
+    _gamma: 'foobar',
+    _delta: 'foobar',
+    _zeta: 'foobar')
+      true
+    end
+    # rubocop:enable all
+  end
+end
+
+# rubocop:enable Lint/UnusedMethodArgument
+# rubocop:enable Lint/UselessAccessModifier
+# rubocop:enable Style/AccessModifierDeclarations
+"
+`;

--- a/test/cases/access_modifiers/__snapshots__/jsfmt.spec.js.snap
+++ b/test/cases/access_modifiers/__snapshots__/jsfmt.spec.js.snap
@@ -80,15 +80,15 @@ class AccessModifiersTest < Minitest::Test
       true
     end
 
-    # rubocop:disable all
-    protected def protected_foo(_alpha: \\"foobar\\",
-    _beta: \\"foobar\\",
-    _gamma: \\"foobar\\",
-    _delta: \\"foobar\\",
-    _zeta: \\"foobar\\")
+    protected def protected_foo(
+      _alpha: \\"foobar\\",
+      _beta: \\"foobar\\",
+      _gamma: \\"foobar\\",
+      _delta: \\"foobar\\",
+      _zeta: \\"foobar\\"
+    )
       true
     end
-    # rubocop:enable all
   end
 end
 
@@ -178,15 +178,15 @@ class AccessModifiersTest < Minitest::Test
       true
     end
 
-    # rubocop:disable all
-    protected def protected_foo(_alpha: 'foobar',
-    _beta: 'foobar',
-    _gamma: 'foobar',
-    _delta: 'foobar',
-    _zeta: 'foobar')
+    protected def protected_foo(
+      _alpha: 'foobar',
+      _beta: 'foobar',
+      _gamma: 'foobar',
+      _delta: 'foobar',
+      _zeta: 'foobar'
+    )
       true
     end
-    # rubocop:enable all
   end
 end
 

--- a/test/cases/access_modifiers/access_modifiers.rb
+++ b/test/cases/access_modifiers/access_modifiers.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# rubocop:disable Lint/UnusedMethodArgument
+# rubocop:disable Lint/UselessAccessModifier
+# rubocop:disable Style/AccessModifierDeclarations
+
+class AccessModifiersTest < Minitest::Test
+  def test_simple_modifiers
+    instance = SimpleModifiers.new
+
+    assert_includes instance.public_methods, :public_foo
+    assert_includes instance.protected_methods, :protected_foo
+    assert_includes instance.protected_methods, :protected_bar
+    assert_includes instance.private_methods, :private_foo
+  end
+
+  def test_complex_modifiers
+    instance = ComplexCommandModifiers.new
+
+    assert_includes instance.public_methods, :public_custom_method_helper_prefix
+    assert_includes instance.public_methods, :public_foo
+    assert_includes instance.protected_methods, :protected_custom_method_helper_prefix
+    assert_includes instance.protected_methods, :protected_foo
+    assert_includes instance.private_methods, :private_foo
+  end
+
+  private
+
+  class SimpleModifiers
+    public
+    def public_foo() end
+
+    protected
+    def protected_foo() end
+
+    # testing
+    protected # testing
+    # testing
+    def protected_bar() end
+
+    private
+    def private_foo() end
+  end
+
+  class ComplexCommandModifiers
+    def self.custom_method_helper(method_name)
+      method_name
+    end
+
+    custom_method_helper def public_custom_method_helper_prefix(arg)
+      true
+    end
+
+    public def public_foo(arg)
+      true
+    end
+
+    protected custom_method_helper def protected_custom_method_helper_prefix(arg)
+      true
+    end
+
+    private def private_foo(_alpha: 'foobar', _beta: 'foobar', _gamma: 'foobar', _delta: 'foobar', _zeta: 'foobar')
+      true
+    end
+
+    # rubocop:disable all
+    protected def protected_foo _alpha: 'foobar', _beta: 'foobar', _gamma: 'foobar', _delta: 'foobar', _zeta: 'foobar'
+      true
+    end
+    # rubocop:enable all
+  end
+end
+
+# rubocop:enable Lint/UnusedMethodArgument
+# rubocop:enable Lint/UselessAccessModifier
+# rubocop:enable Style/AccessModifierDeclarations

--- a/test/cases/access_modifiers/access_modifiers.rb
+++ b/test/cases/access_modifiers/access_modifiers.rb
@@ -63,11 +63,9 @@ class AccessModifiersTest < Minitest::Test
       true
     end
 
-    # rubocop:disable all
     protected def protected_foo _alpha: 'foobar', _beta: 'foobar', _gamma: 'foobar', _delta: 'foobar', _zeta: 'foobar'
       true
     end
-    # rubocop:enable all
   end
 end
 

--- a/test/cases/access_modifiers/jsfmt.spec.js
+++ b/test/cases/access_modifiers/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/test/cases/method/__snapshots__/jsfmt.spec.js.snap
+++ b/test/cases/method/__snapshots__/jsfmt.spec.js.snap
@@ -108,6 +108,25 @@ foo.foo aaaaaaa,
         ggggggg,
         hhhhhhh,
         iiiiiii
+Foo::Bar::Baz.qux aaaaaaa,
+                  bbbbbbb,
+                  ccccccc,
+                  ddddddd,
+                  eeeeeee,
+                  fffffff,
+                  ggggggg,
+                  hhhhhhh,
+                  iiiiiii
+Foo::Bar::Baz.qux aaaaaaa,
+                  bbbbbbb,
+                  ccccccc,
+                  ddddddd,
+                  eeeeeee,
+                  fffffff,
+                  ggggggg,
+                  hhhhhhh,
+                  iiiiiii,
+                  &block
 
 foo(*bar)
 foo(**baz)
@@ -237,6 +256,25 @@ foo.foo aaaaaaa,
         ggggggg,
         hhhhhhh,
         iiiiiii
+Foo::Bar::Baz.qux aaaaaaa,
+                  bbbbbbb,
+                  ccccccc,
+                  ddddddd,
+                  eeeeeee,
+                  fffffff,
+                  ggggggg,
+                  hhhhhhh,
+                  iiiiiii
+Foo::Bar::Baz.qux aaaaaaa,
+                  bbbbbbb,
+                  ccccccc,
+                  ddddddd,
+                  eeeeeee,
+                  fffffff,
+                  ggggggg,
+                  hhhhhhh,
+                  iiiiiii,
+                  &block
 
 foo(*bar)
 foo(**baz)

--- a/test/cases/method/__snapshots__/jsfmt.spec.js.snap
+++ b/test/cases/method/__snapshots__/jsfmt.spec.js.snap
@@ -42,6 +42,26 @@ def foo(
   \\"what\\"
 end
 
+def foo(alpha, beta, *gamma, delta, epsilon:, zeta:, eta: 1, **theta, &block)
+  \\"what\\"
+end
+
+def foo(
+  alpha:,
+  beta:,
+  gamma:,
+  delta:,
+  epsilon:,
+  zeta:,
+  eta:,
+  theta:,
+  iota:,
+  kappa:,
+  lambda:
+)
+  \\"what\\"
+end
+
 def foo(alpha)
   1
 end
@@ -169,6 +189,26 @@ def self.foo(); end
 def self.foo(alpha); end
 
 def self.foo(alpha); end
+
+def foo(alpha, beta, *gamma, delta, epsilon:, zeta:, eta: 1, **theta, &block)
+  'what'
+end
+
+def foo(
+  alpha:,
+  beta:,
+  gamma:,
+  delta:,
+  epsilon:,
+  zeta:,
+  eta:,
+  theta:,
+  iota:,
+  kappa:,
+  lambda:
+)
+  'what'
+end
 
 def foo(alpha, beta, *gamma, delta, epsilon:, zeta:, eta: 1, **theta, &block)
   'what'

--- a/test/cases/method/method.rb
+++ b/test/cases/method/method.rb
@@ -31,6 +31,14 @@ def foo(alpha:, beta:, gamma:, delta:, epsilon:, zeta:, eta:, theta:, iota:, kap
   'what'
 end
 
+def foo alpha, beta, *gamma, delta, epsilon:, zeta:, eta: 1, **theta, &block
+  'what'
+end
+
+def foo alpha:, beta:, gamma:, delta:, epsilon:, zeta:, eta:, theta:, iota:, kappa:, lambda:
+  'what'
+end
+
 def foo(alpha); 1; end
 
 def foo(*); end

--- a/test/cases/method/method.rb
+++ b/test/cases/method/method.rb
@@ -49,6 +49,8 @@ foo(aaaaaaa, bbbbbbb, ccccccc, ddddddd, eeeeeee, fffffff, ggggggg, hhhhhhh, &blo
 
 foo aaaaaaa, bbbbbbb, ccccccc, ddddddd, eeeeeee, fffffff, ggggggg, hhhhhhh, iiiiiii
 foo.foo aaaaaaa, bbbbbbb, ccccccc, ddddddd, eeeeeee, fffffff, ggggggg, hhhhhhh, iiiiiii
+Foo::Bar::Baz.qux aaaaaaa, bbbbbbb, ccccccc, ddddddd, eeeeeee, fffffff, ggggggg, hhhhhhh, iiiiiii
+Foo::Bar::Baz.qux aaaaaaa, bbbbbbb, ccccccc, ddddddd, eeeeeee, fffffff, ggggggg, hhhhhhh, iiiiiii, &block
 
 foo(*bar)
 foo(**baz)


### PR DESCRIPTION
This PR adds support for two things:

- Adding newlines around access modifiers - https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb

- Align `def ... end` with accessor definitions following `EnforcedStyleAlignWith: start_of_line` - https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/layout/def_end_alignment.rb