### PR TITLE
Add minitest for assign.rb

### DIFF
--- a/test/cases/assign/__snapshots__/jsfmt.spec.js.snap
+++ b/test/cases/assign/__snapshots__/jsfmt.spec.js.snap
@@ -4,78 +4,176 @@ exports[`for the off.json config assign.rb matches expected output 1`] = `
 "# frozen_string_literal: true
 
 # rubocop:disable Lint/UselessAssignment, Style/ParallelAssignment
+# rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/LineLength
+# rubocop:disable Metrics/ClassLength
 
-a = 1
+class AssignTest < Minitest::Test
+  def test_assignment
+    a = 1
+    assert_equal 1, a
 
-a =
-  begin
-    2
+    a =
+      begin
+        2
+      end
+    assert_equal 2, a
   end
 
-a, b, c = [1, 2, 3]
+  def test_parallel_assignment
+    a, b, c = [1, 2, 3]
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
 
-a = 1, 2, 3
+    a = 1, 2, 3
+    assert_equal [1, 2, 3], a
 
-a, b, c = 1, 2, 3
+    a, b, c = 1, 2, 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
 
-a, b, c = 1, 2, 3
+    a, b, c = 1, 2, 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
 
-a, b, c = 1, 2, 3
+    a, b, c = 1, 2, 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
 
-a, b, c = 1, 2, 3
+    a, b, c = 1, 2, 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
+  end
 
-a, *b = 1, 2, 3
+  def test_assign_with_splat_operator
+    a, *b = 1, 2, 3
+    assert_equal 1, a
+    assert_equal [2, 3], b
 
-a, *b, c, d = 1, 2, 3
+    a, *b, c, d = 1, 2, 3
+    assert_equal 1, a
+    assert_equal [], b
+    assert_equal 2, c
+    assert_equal 3, d
 
-a, * = 1, 2, 3
+    a, * = 1, 2, 3
+    assert_equal 1, a
 
-a = *a
+    a = *a
+    assert_equal [1], a
 
-(a, b), c = [1, 2], 3
+    (a, b), c = [1, 2], 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
 
-* = [1, 2, 3]
+    * = [1, 2, 3]
 
-*, a = [1, 2, 3]
+    *, a = [1, 2, 3]
+    assert_equal 3, a
+  end
 
-super_super_super_long, super_super_super_long, super_super_super_long =
-  super_super_super_super_super_long,
-  super_super_super_super_super_long,
-  super_super_super_super_super_long
+  def test_or_equals_operator
+    a = 2
+    a ||= 1
+    assert_equal 2, a
+  end
 
-a ||= 1
+  def test_long_variable_assignment
+    super_super_super_super_super_long = \\"bar\\"
+    super_super_super_long, super_super_super_long, super_super_super_long =
+      super_super_super_super_super_long,
+      super_super_super_super_super_long,
+      super_super_super_super_super_long
+    assert_equal super_super_super_long, \\"bar\\"
 
-a ||=
-  super_super_super_super_super_super_super_super_super_super_super_super_long
+    a = 2
+    a ||=
+      super_super_super_super_super_super_super_super_super_super_super_super_long
+    assert_equal 2, a
 
-a = [
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long
-]
+    super_super_super_super_super_super_super_super_super_super_super_super_long =
+      \\"foo\\"
+    a = [
+      super_super_super_super_super_super_super_super_super_super_super_long,
+      super_super_super_super_super_super_super_super_super_super_super_long,
+      super_super_super_super_super_super_super_super_super_super_super_long
+    ]
+    assert_equal %w[foo foo foo], a
+  end
 
-a = {
-  :a => super_super_super_super_super_super_super_super_super_super_long,
-  :b => super_super_super_super_super_super_super_super_super_super_long,
-  :c => super_super_super_super_super_super_super_super_super_super_long
-}
+  def test_assign_hash
+    a = {
+      :a => super_super_super_super_super_super_super_super_super_super_long,
+      :b => super_super_super_super_super_super_super_super_super_super_long,
+      :c => super_super_super_super_super_super_super_super_super_super_long
+    }
+    assert_equal \\"{ a: 'foo', b: 'foo', c: 'foo' }\\", a.to_s
+  end
 
-# rubocop:disable Lint/UnneededCopDisableDirective
-# rubocop:disable Layout/MultilineMethodCallIndentation
-# I know, I know
-a = [super_super_super_super_long, super_super_super_super_long].sort
+  def test_assign_with_sort
+    # rubocop:disable Lint/UnneededCopDisableDirective
+    # rubocop:disable Layout/MultilineMethodCallIndentation
+    # I know, I know
+    super_super_super_super_long = \\"baz\\"
+    a = [super_super_super_super_long, super_super_super_super_long].sort
+    assert_equal %w[baz baz], a
 
-a = { :a => super_super_super_super_long, :b => super_super_super_super_long }
-  .sort
-# rubocop:enable Layout/MultilineMethodCallIndentation
-# rubocop:enable Lint/UnneededCopDisableDirective
+    a = {
+      :a => super_super_super_super_long, :b => super_super_super_super_long
+    }
+      .sort
+    assert_equal \\"{ a: 'baz', b: 'baz' }\\", a
 
-a.a = 1
+    # rubocop:enable Layout/MultilineMethodCallIndentation
+    # rubocop:enable Lint/UnneededCopDisableDirective
+  end
 
-super_super_super_long.super_super_super_super_super_super_super_long =
-  super_super_super_super_super_super_super_super_super_super_super_long
+  def test_setter_methods
+    a =
+      Struct.new do
+        def a=(arg)
+          @arg = arg
+        end
+
+        def a
+          @arg
+        end
+      end
+
+    a.a = 1
+    assert_equal 1, a.a
+
+    super_super_super_long =
+      Struct.new do
+        def super_super_super_super_super_super_super_long=(arg)
+          @arg = arg
+        end
+      end
+
+    super_super_super_super_super_super_super_super_super_super_super_long = 1
+
+    super_super_super_long.super_super_super_super_super_super_super_long =
+      super_super_super_super_super_super_super_super_super_super_super_long
+
+    assert_equal(
+      super_super_super_long.super_super_super_super_super_super_super_long,
+      1
+    )
+  end
+end
 
 # rubocop:enable Lint/UselessAssignment, Style/ParallelAssignment
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/LineLength
+# rubocop:enable Metrics/ClassLength
 "
 `;
 
@@ -83,76 +181,173 @@ exports[`for the on.json config assign.rb matches expected output 1`] = `
 "# frozen_string_literal: true
 
 # rubocop:disable Lint/UselessAssignment, Style/ParallelAssignment
+# rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/LineLength
+# rubocop:disable Metrics/ClassLength
 
-a = 1
+class AssignTest < Minitest::Test
+  def test_assignment
+    a = 1
+    assert_equal 1, a
 
-a =
-  begin
-    2
+    a =
+      begin
+        2
+      end
+    assert_equal 2, a
   end
 
-a, b, c = [1, 2, 3]
+  def test_parallel_assignment
+    a, b, c = [1, 2, 3]
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
 
-a = 1, 2, 3
+    a = 1, 2, 3
+    assert_equal [1, 2, 3], a
 
-a, b, c = 1, 2, 3
+    a, b, c = 1, 2, 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
 
-a, b, c = 1, 2, 3
+    a, b, c = 1, 2, 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
 
-a, b, c = 1, 2, 3
+    a, b, c = 1, 2, 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
 
-a, b, c = 1, 2, 3
+    a, b, c = 1, 2, 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
+  end
 
-a, *b = 1, 2, 3
+  def test_assign_with_splat_operator
+    a, *b = 1, 2, 3
+    assert_equal 1, a
+    assert_equal [2, 3], b
 
-a, *b, c, d = 1, 2, 3
+    a, *b, c, d = 1, 2, 3
+    assert_equal 1, a
+    assert_equal [], b
+    assert_equal 2, c
+    assert_equal 3, d
 
-a, * = 1, 2, 3
+    a, * = 1, 2, 3
+    assert_equal 1, a
 
-a = *a
+    a = *a
+    assert_equal [1], a
 
-(a, b), c = [1, 2], 3
+    (a, b), c = [1, 2], 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
 
-* = [1, 2, 3]
+    * = [1, 2, 3]
 
-*, a = [1, 2, 3]
+    *, a = [1, 2, 3]
+    assert_equal 3, a
+  end
 
-super_super_super_long, super_super_super_long, super_super_super_long =
-  super_super_super_super_super_long,
-  super_super_super_super_super_long,
-  super_super_super_super_super_long
+  def test_or_equals_operator
+    a = 2
+    a ||= 1
+    assert_equal 2, a
+  end
 
-a ||= 1
+  def test_long_variable_assignment
+    super_super_super_super_super_long = 'bar'
+    super_super_super_long, super_super_super_long, super_super_super_long =
+      super_super_super_super_super_long,
+      super_super_super_super_super_long,
+      super_super_super_super_super_long
+    assert_equal super_super_super_long, 'bar'
 
-a ||=
-  super_super_super_super_super_super_super_super_super_super_super_super_long
+    a = 2
+    a ||=
+      super_super_super_super_super_super_super_super_super_super_super_super_long
+    assert_equal 2, a
 
-a = [
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long,
-]
+    super_super_super_super_super_super_super_super_super_super_super_super_long =
+      'foo'
+    a = [
+      super_super_super_super_super_super_super_super_super_super_super_long,
+      super_super_super_super_super_super_super_super_super_super_super_long,
+      super_super_super_super_super_super_super_super_super_super_super_long,
+    ]
+    assert_equal %w[foo foo foo], a
+  end
 
-a = {
-  a: super_super_super_super_super_super_super_super_super_super_long,
-  b: super_super_super_super_super_super_super_super_super_super_long,
-  c: super_super_super_super_super_super_super_super_super_super_long,
-}
+  def test_assign_hash
+    a = {
+      a: super_super_super_super_super_super_super_super_super_super_long,
+      b: super_super_super_super_super_super_super_super_super_super_long,
+      c: super_super_super_super_super_super_super_super_super_super_long,
+    }
+    assert_equal \\"{ a: 'foo', b: 'foo', c: 'foo' }\\", a.to_s
+  end
 
-# rubocop:disable Lint/UnneededCopDisableDirective
-# rubocop:disable Layout/MultilineMethodCallIndentation
-# I know, I know
-a = [super_super_super_super_long, super_super_super_super_long].sort
+  def test_assign_with_sort
+    # rubocop:disable Lint/UnneededCopDisableDirective
+    # rubocop:disable Layout/MultilineMethodCallIndentation
+    # I know, I know
+    super_super_super_super_long = 'baz'
+    a = [super_super_super_super_long, super_super_super_super_long].sort
+    assert_equal %w[baz baz], a
 
-a = { a: super_super_super_super_long, b: super_super_super_super_long }.sort
-# rubocop:enable Layout/MultilineMethodCallIndentation
-# rubocop:enable Lint/UnneededCopDisableDirective
+    a = { a: super_super_super_super_long, b: super_super_super_super_long }
+      .sort
+    assert_equal \\"{ a: 'baz', b: 'baz' }\\", a
 
-a.a = 1
+    # rubocop:enable Layout/MultilineMethodCallIndentation
+    # rubocop:enable Lint/UnneededCopDisableDirective
+  end
 
-super_super_super_long.super_super_super_super_super_super_super_long =
-  super_super_super_super_super_super_super_super_super_super_super_long
+  def test_setter_methods
+    a =
+      Struct.new do
+        def a=(arg)
+          @arg = arg
+        end
+
+        def a
+          @arg
+        end
+      end
+
+    a.a = 1
+    assert_equal 1, a.a
+
+    super_super_super_long =
+      Struct.new do
+        def super_super_super_super_super_super_super_long=(arg)
+          @arg = arg
+        end
+      end
+
+    super_super_super_super_super_super_super_super_super_super_super_long = 1
+
+    super_super_super_long.super_super_super_super_super_super_super_long =
+      super_super_super_super_super_super_super_super_super_super_super_long
+
+    assert_equal(
+      super_super_super_long.super_super_super_super_super_super_super_long,
+      1,
+    )
+  end
+end
 
 # rubocop:enable Lint/UselessAssignment, Style/ParallelAssignment
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/LineLength
+# rubocop:enable Metrics/ClassLength
 "
 `;

--- a/test/cases/assign/assign.rb
+++ b/test/cases/assign/assign.rb
@@ -1,73 +1,123 @@
 # frozen_string_literal: true
 
 # rubocop:disable Lint/UselessAssignment, Style/ParallelAssignment
+# rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/LineLength
 
-a = 1
+class AssignTest < Minitest::Test
+  def test_assignment
+    a = 1
+    assert_equal 1, a
 
-a =
-  begin
-    2
+    a =
+      begin
+        2
+      end
+    assert_equal 2, a
+
+    a, b, c = [1, 2, 3]
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
+
+    a = 1, 2, 3
+    assert_equal [1, 2, 3], a
+
+    a, b, c = 1, 2, 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
+
+    (a, b, c) = 1, 2, 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
+
+    ((a, b, c)) = 1, 2, 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
+
+    (((a, b, c))) = 1, 2, 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
+
+    a, *b = 1, 2, 3
+    assert_equal 1, a
+    assert_equal [2, 3], b
+
+    a, *b, c, d = 1, 2, 3
+    assert_equal 1, a
+    assert_equal [], b
+    assert_equal 2, c
+    assert_equal 3, d
+
+    a, * = 1, 2, 3
+    assert_equal 1, a
+
+    a = *a
+    assert_equal [1], a
+
+    (a, b), c = [1, 2], 3
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
+
+    * = [1, 2, 3]
+
+    *, a = [1, 2, 3]
+    assert_equal 3, a
+
+    super_super_super_super_super_long = 'bar'
+    super_super_super_long, super_super_super_long, super_super_super_long =
+      super_super_super_super_super_long, super_super_super_super_super_long, super_super_super_super_super_long
+    assert_equal super_super_super_long, 'bar'
+
+    a = 2
+    a ||= 1
+    assert_equal 2, a
+
+    a = 2
+    a ||= super_super_super_super_super_super_super_super_super_super_super_super_long
+    assert_equal 2, a
+
+    super_super_super_super_super_super_super_super_super_super_super_super_long = 'foo'
+    a = [
+      super_super_super_super_super_super_super_super_super_super_super_long,
+      super_super_super_super_super_super_super_super_super_super_super_long,
+      super_super_super_super_super_super_super_super_super_super_super_long
+    ]
+    assert_equal ['foo', 'foo', 'foo'], a
+
+    a = {
+      a: super_super_super_super_super_super_super_super_super_super_long,
+      b: super_super_super_super_super_super_super_super_super_super_long,
+      c: super_super_super_super_super_super_super_super_super_super_long
+    }
+    assert_equal "{ a: 'foo', b: 'foo', c: 'foo' }", a.to_s
+
+    # rubocop:disable Lint/UnneededCopDisableDirective
+    # rubocop:disable Layout/MultilineMethodCallIndentation
+    # I know, I know
+    super_super_super_super_long = 'baz'
+    a = [
+      super_super_super_super_long,
+      super_super_super_super_long
+    ].sort
+    assert_equal ['baz', 'baz'], a
+
+    a = {
+      a: super_super_super_super_long,
+      b: super_super_super_super_long
+    }.sort
+    assert_equal "{ a: 'baz', b: 'baz' }", a
+    # rubocop:enable Layout/MultilineMethodCallIndentation
+    # rubocop:enable Lint/UnneededCopDisableDirective
+
   end
-
-a, b, c = [1, 2, 3]
-
-a = 1, 2, 3
-
-a, b, c = 1, 2, 3
-
-(a, b, c) = 1, 2, 3
-
-((a, b, c)) = 1, 2, 3
-
-(((a, b, c))) = 1, 2, 3
-
-a, *b = 1, 2, 3
-
-a, *b, c, d = 1, 2, 3
-
-a, * = 1, 2, 3
-
-a = *a
-
-(a, b), c = [1, 2], 3
-
-* = [1, 2, 3]
-
-*, a = [1, 2, 3]
-
-super_super_super_long, super_super_super_long, super_super_super_long =
-  super_super_super_super_super_long, super_super_super_super_super_long, super_super_super_super_super_long
-
-a ||= 1
-
-a ||= super_super_super_super_super_super_super_super_super_super_super_super_long
-
-a = [
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_super_long
-]
-
-a = {
-  a: super_super_super_super_super_super_super_super_super_super_long,
-  b: super_super_super_super_super_super_super_super_super_super_long,
-  c: super_super_super_super_super_super_super_super_super_super_long
-}
-
-# rubocop:disable Lint/UnneededCopDisableDirective
-# rubocop:disable Layout/MultilineMethodCallIndentation
-# I know, I know
-a = [
-  super_super_super_super_long,
-  super_super_super_super_long
-].sort
-
-a = {
-  a: super_super_super_super_long,
-  b: super_super_super_super_long
-}.sort
-# rubocop:enable Layout/MultilineMethodCallIndentation
-# rubocop:enable Lint/UnneededCopDisableDirective
+end
 
 a.a = 1
 
@@ -75,3 +125,6 @@ super_super_super_long.super_super_super_super_super_super_super_long =
   super_super_super_super_super_super_super_super_super_super_super_long
 
 # rubocop:enable Lint/UselessAssignment, Style/ParallelAssignment
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/LineLength

--- a/test/cases/assign/assign.rb
+++ b/test/cases/assign/assign.rb
@@ -4,6 +4,7 @@
 # rubocop:disable Metrics/MethodLength
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/LineLength
+# rubocop:disable Metrics/ClassLength
 
 class AssignTest < Minitest::Test
   def test_assignment
@@ -15,7 +16,9 @@ class AssignTest < Minitest::Test
         2
       end
     assert_equal 2, a
+  end
 
+  def test_parallel_assignment
     a, b, c = [1, 2, 3]
     assert_equal 1, a
     assert_equal 2, b
@@ -43,7 +46,9 @@ class AssignTest < Minitest::Test
     assert_equal 1, a
     assert_equal 2, b
     assert_equal 3, c
+  end
 
+  def test_assign_with_splat_operator
     a, *b = 1, 2, 3
     assert_equal 1, a
     assert_equal [2, 3], b
@@ -69,15 +74,19 @@ class AssignTest < Minitest::Test
 
     *, a = [1, 2, 3]
     assert_equal 3, a
+  end
 
+  def test_or_equals_operator
+    a = 2
+    a ||= 1
+    assert_equal 2, a
+  end
+
+  def test_long_variable_assignment
     super_super_super_super_super_long = 'bar'
     super_super_super_long, super_super_super_long, super_super_super_long =
       super_super_super_super_super_long, super_super_super_super_super_long, super_super_super_super_super_long
     assert_equal super_super_super_long, 'bar'
-
-    a = 2
-    a ||= 1
-    assert_equal 2, a
 
     a = 2
     a ||= super_super_super_super_super_super_super_super_super_super_super_super_long
@@ -90,14 +99,18 @@ class AssignTest < Minitest::Test
       super_super_super_super_super_super_super_super_super_super_super_long
     ]
     assert_equal ['foo', 'foo', 'foo'], a
+  end
 
+  def test_assign_hash
     a = {
       a: super_super_super_super_super_super_super_super_super_super_long,
       b: super_super_super_super_super_super_super_super_super_super_long,
       c: super_super_super_super_super_super_super_super_super_super_long
     }
     assert_equal "{ a: 'foo', b: 'foo', c: 'foo' }", a.to_s
+  end
 
+  def test_assign_with_sort
     # rubocop:disable Lint/UnneededCopDisableDirective
     # rubocop:disable Layout/MultilineMethodCallIndentation
     # I know, I know
@@ -113,18 +126,45 @@ class AssignTest < Minitest::Test
       b: super_super_super_super_long
     }.sort
     assert_equal "{ a: 'baz', b: 'baz' }", a
+
     # rubocop:enable Layout/MultilineMethodCallIndentation
     # rubocop:enable Lint/UnneededCopDisableDirective
+  end
 
+  def test_setter_methods
+    a = Struct.new do
+      def a=(arg)
+        @arg = arg
+      end
+
+      def a
+        @arg
+      end
+    end
+
+    a.a = 1
+    assert_equal 1, a.a
+
+    super_super_super_long = Struct.new do
+      def super_super_super_super_super_super_super_long=(arg)
+        @arg = arg
+      end
+    end
+
+    super_super_super_super_super_super_super_super_super_super_super_long = 1
+
+    super_super_super_long.super_super_super_super_super_super_super_long =
+      super_super_super_super_super_super_super_super_super_super_super_long
+
+    assert_equal(
+      super_super_super_long.super_super_super_super_super_super_super_long,
+      1
+    )
   end
 end
-
-a.a = 1
-
-super_super_super_long.super_super_super_super_super_super_super_long =
-  super_super_super_super_super_super_super_super_super_super_super_long
 
 # rubocop:enable Lint/UselessAssignment, Style/ParallelAssignment
 # rubocop:enable Metrics/MethodLength
 # rubocop:enable Metrics/AbcSize
 # rubocop:enable Metrics/LineLength
+# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
Why:
We would like for the assign.rb file for the test snapshots to also be a
minitest test so that we can run the ruby tests after the prettier
formatting process an validate that the assignments are equivalent post
formatting.

this commit:
Introduces minitest to '/test/cases/assign.rb'

issue: [#120](https://github.com/prettier/plugin-ruby/issues/120)