### PR TITLE
Jts ct ruby specs

### DIFF
--- a/spec/blocks_spec.rb
+++ b/spec/blocks_spec.rb
@@ -24,6 +24,24 @@ describe 'Blocks' do
     end
   end
 
+  describe 'a block with no parameter and a body' do
+    it 'surrounds the block content with one space' do
+      assert_equal_and_valid(
+        'loop {   true}',
+        'loop { true }'
+      )
+    end
+  end
+
+  describe 'a block with a parameter and no body' do
+    it 'inserts one space around the parameter' do
+      assert_equal_and_valid(
+        'loop {|el|   }',
+        'loop { |el| }'
+      )
+    end
+  end
+
   def assert_equal_and_valid(input, expected)
     result = apply_prettier(input)
     assert_equal expected, result

--- a/spec/blocks_spec.rb
+++ b/spec/blocks_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'open3'
+
+# rubocop:disable Metrics/BlockLength
+
+describe 'Blocks' do
+  describe 'an empty block' do
+    it 'renders with one space' do
+      assert_equal_and_valid(
+        'loop {}',
+        'loop { }'
+      )
+    end
+  end
+
+  describe 'a block with a paramer and a body' do
+    it 'inserts a space arount the content and paramter' do
+      assert_equal_and_valid(
+        'loop {|el|el + 1}',
+        'loop { |el| el + 1 }'
+      )
+    end
+  end
+
+  def assert_equal_and_valid(input, expected)
+    result = apply_prettier(input)
+    assert_equal expected, result
+    ensure_valid(expected)
+  end
+
+  def ensure_valid(string)
+    _, stderr_str, status = Open3.capture3('ruby -c', stdin_data: string)
+    assert_equal status.success?, true, stderr_str
+  end
+
+  def apply_prettier(string)
+    file = write_string_to_tempfile(string)
+    run_prettier_on_file(file.path)
+  end
+
+  def write_string_to_tempfile(string)
+    Tempfile.new('prettier-ruby-test.rb').tap do |file|
+      file.write(string)
+      file.close
+    end
+  end
+
+  def run_prettier_on_file(path)
+    `bin/print #{path}`.rstrip
+  end
+end
+
+# rubocop:enable Metrics/BlockLength

--- a/src/nodes/blocks.js
+++ b/src/nodes/blocks.js
@@ -110,11 +110,14 @@ const printBlock = (path, opts, print) => {
     return concat([breakParent, doBlock]);
   }
 
+  const blockContents = statements.body[0].body;
+  const blockContentsEmpty = blockContents.length === 0;
+
   const braceBlock = concat([
     " { ",
     variables ? path.call(print, "body", 0) : "",
     path.call(print, "body", 1),
-    " }"
+    blockContentsEmpty ? "}" : " }"
   ]);
 
   return group(ifBreak(doBlock, braceBlock));

--- a/test/cases/__snapshots__/blocks.test.js.snap
+++ b/test/cases/__snapshots__/blocks.test.js.snap
@@ -39,6 +39,8 @@ end
 
 loop { super_super_super_super_super_super_super_super_super_super_super_long }
 
+loop { |i| }
+
 loop { |i| 1 }
 
 loop { |i; j| 1 }

--- a/test/cases/blocks.rb
+++ b/test/cases/blocks.rb
@@ -42,6 +42,8 @@ loop do
   super_super_super_super_super_super_super_super_super_super_super_long
 end
 
+loop { |i| }
+
 loop { |i| 1 }
 
 loop { |i; j| 1 }


### PR DESCRIPTION
Commit 1:

Introduce spec helpers  …
Why:
We would like to be able to have explicit tests that will allow to
ensure that prettier-ruby behaves as intended. Ideally these tests can
be run independently from the test suite and could allow for TDD.

This commit:
introduces an assert_equal_and_valid method which takes an input string
and an expected output string and will validate that prettier can be
applied to the expected string by:

writing the expected string to a Tempfile, 'prettier-ruby-test.rb',
applying prettier-ruby to the Tempfile with the 'bin/print' executable,
asserting with minitest that the resultant file is equal to the expected
string,
and executing the resultant file with Open3 to capture any stderr and
status to validate that the formatted code can be run without throwing
an error.

Two example specs are provided in this commit to demonstrate the spec
helpers usage

Co-authored-by: christoomey <chris@thoughtbot.com>
Co-authored-by: johnschoeman <johnschoeman1617@gmail.com>


---

Commit 2:

Fix block spacing bug  …
Why:
Currently if a block is given just a parameter and no actual content the
formatter will return a block with an extra space, which is a rubocop
error: 'Layout/ExtraSpacing: Layout/ExtraSpacing: Unnecessary spacing
detected.'

for example:
```ruby
{ |el| }
```
becomes
```ruby
{ |el|  }
```

This commit:
Updates the block node to not add an extra space if the block has no
contents.

Co-authored-by: christoomey <chris@thoughtbot.com>
Co-authored-by: johnschoeman <johnschoeman1617@gmail.com>