### PR TITLE
Jts blocks mini test

### DIFF
--- a/test/cases/__snapshots__/blocks.test.js.snap
+++ b/test/cases/__snapshots__/blocks.test.js.snap
@@ -4,117 +4,238 @@ exports[`blocks.rb matches expected output 1`] = `
 "# frozen_string_literal: true
 
 # rubocop:disable Lint/UnusedBlockArgument
-
-loop { 1 }
-
-loop { 1 }
-
-loop do
-  # foobar
-end
-
-port ENV.fetch('PORT') { 3000 }
-
-test 'foobar' do
-end
-
-te.st 'foobar' do
-end
-
-test 'foobar' do
-  foobar
-end
-
-te.st 'foobar' do
-  foobar
-end
-
-test 'foobar', &:to_s
-
-te.st 'foobar', &:to_s
-
-loop do
-  super_super_super_super_super_super_super_super_super_super_super_super_long
-end
-
-loop { super_super_super_super_super_super_super_super_super_super_super_long }
-
-loop { |i| 1 }
-
-loop { |i; j| 1 }
-
-loop { |i| i }
-
-loop { |*| i }
-
-loop { |(a, b)| i }
-
-loop { |a, (b, c), d, *e| i }
-
-loop do |i|
-  super_super_super_super_super_super_super_super_super_super_super_super_long
-end
-
-loop { |i| super_super_super_super_super_super_super_super_super_super_long }
-
+# rubocop:disable Metrics/ClassLength
 # rubocop:disable Metrics/LineLength
-define_method :long_method_name_that_forces_overflow do |_some_long_argument_that_overflows = Time.now, _other_arg = nil|
-end
-# rubocop:enable Metrics/LineLength
+# rubocop:disable Layout/ExtraSpacing
 
-some_method.each do |foo|
-  bar
-  baz
-end.to_i
+class BlockTest < Minitest::Text
+  def test_inline_block
+    a = 0
+    test_method { a = 1 }
 
-[
-  super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_long
-].to_s
+    assert_equal a, 1
+  end
 
-{
-  a: 'super_super_super_super_super_super_super_super_super_super_long',
-  b: 'super_super_super_super_super_super_super_super_super_super_long'
-}.to_s
+  def test_multiline_block
+    a = 0
+    test_method { a = 1 }
 
-loop(&:to_s)
+    assert_equal a, 1
+  end
 
-loop(&:to_s)
+  def test_block_with_only_comment
+    result =
+      test_method 'foo' do
+        # foobar
+      end
+    assert_equal result, 'foo'
+  end
 
-loop do |i|
-  i.to_s
-  i.next
-end
+  def test_block_with_parameters_and_inline_syntax
+    a = [1, 2, 3]
+    result = a.map { |el| el * 2 }
+    assert_equal result, [2, 4, 6]
+  end
 
-loop { |i| i.to_s :db }
+  def test_block_with_parameters_and_do_end_syntax
+    a = [1, 2, 3]
+    result = a.map { |el| el * 2 }
+    assert_equal result, [2, 4, 6]
+  end
 
-loop { |i, j| i.to_s }
+  def test_block_with_parameter_and_no_block_content
+    a = [1, 2, 3]
+    result = a.map { |*|  }
+    assert_equal result, [nil, nil, nil]
+  end
 
-[1, 2, 3].each do |i|
-  p i
-end
+  def test_block_with_parameters_four
+    arr = [[1, 2], [3, 4]]
+    result = arr.map { |(a, b)| a + b }
+    assert_equal result, [3, 7]
+  end
 
-def change
-  change_table :foo do
-    column :bar
+  def test_block_with_parameters_five
+    arr = [[1, [2, 3], 4, 5, 6, 7]]
+    result = arr.map { |a, (b, c), d, *e| \\"#{a}, #{b}, #{c}, #{d}, #{e}\\" }
+    assert_equal result, ['1, 2, 3, 4, [5, 6, 7]']
+  end
+
+  def test_block_with_method_call_one
+    arr = ['a', :b, 3]
+    result = arr.map(&:to_s)
+    assert_equal result, %w[a b 3]
+  end
+
+  def test_block_with_method_call_two
+    arr = [[1, 2], [3, 4]]
+    result = arr.map { |i, j| i.to_s }
+    assert_equal result, [%w[1 2], %w[a b]]
+  end
+
+  loop { |i| 1 }
+
+  def test_block_with_only_parameter
+    result = test_method { |i|  }
+    assert_equal result, ''
+  end
+
+  def test_block_with_method_call_three
+    arr = ['a', :b, 3]
+    result = arr.map(&:to_s)
+    assert_equal result, %w[a b 3]
+  end
+
+  def test_block_with_method_call_four
+    arr = [1, 2, 3]
+    result =
+      arr.map do |i|
+        i.to_s
+        i.next
+      end
+    assert_equal result, %w[a b c]
+  end
+
+  def test_blocks_with_parameters_and_long_contents_one
+    super_super_super_super_super_super_super_super_super_super_super_super_long =
+      'foo'
+    result =
+      test_method do |x|
+        super_super_super_super_super_super_super_super_super_super_super_super_long
+      end
+
+    assert_equal result, 'foo'
+  end
+
+  def test_blocks_with_paramters_and_long_contents_two
+    super_super_super_super_super_super_super_super_super_super_super_long =
+      'foo'
+    blk =
+      proc do |i|
+        super_super_super_super_super_super_super_super_super_super_super_long
+      end
+
+    result = blk.call
+
+    assert_equal result, 'foo'
+  end
+
+  def test_block_for_method
+    test_method 'foobar' do
+    end
+
+    test_method 'foobar' do
+      foobar
+    end
+
+    assert_equal true, true
+  end
+
+  def test_block_for_object
+    te.st 'foobar' do
+    end
+
+    te.st 'foobar' do
+      foobar
+    end
+
+    assert_equal true, true
+  end
+
+  def test_block_that_makes_a_call_to_the_parameter
+    test 'foobar', &:to_s
+
+    te.st 'foobar', &:to_s
+
+    assert_equal true, true
+  end
+
+  def test_block_with_symbol_proc
+    test_method(&:to_s)
+
+    assert_equal true, true
+  end
+
+  def test_blocks_with_long_contents
+    loop do
+      super_super_super_super_super_super_super_super_super_super_super_super_long
+    end
+
+    loop do
+      super_super_super_super_super_super_super_super_super_super_super_long
+    end
+
+    assert_equal true, true
+  end
+
+  def test_block_for_port
+    port ENV.fetch('PORT') { 3000 }
+  end
+
+  def test_really_long_method_and_parameter
+    define_method :long_method_name_that_forces_overflow do |_some_long_argument_that_overflows = Time.now, _other_arg = nil|
+    end
+
+    assert_equal true, true
+  end
+
+  def test_block_for_loop
+    arr = []
+
+    [1, 2, 3].each do |i|
+      arr << i
+    end
+
+    assert_equal arr, [1, 2, 3]
+  end
+
+  # rubocop:disable Lint/NestedMethodDefinition
+  def test_block_in_method_definition
+    def change
+      test_method :foo do
+        column :bar
+      end
+    end
+
+    assert_equal true, true
+  end
+  # rubocop:enable Lint/NestedMethodDefinition
+
+  def test_foo_block
+    test_method 'foo', &:to_s
+
+    assert_equal true, true
+  end
+
+  def test_complicated_method_with_block
+    target.method object.map do |arg|
+      arg * 2
+    end
+
+    assert_equal true, true
+  end
+
+  # from ruby test/ruby/test_call.rb
+  def test_call_block
+    assert_nil(
+      (
+        'a'.sub! 'b' do
+        end&.foo do
+        end
+      )
+    )
+  end
+
+  private
+
+  def test_method(arg = '')
+    yield arg
   end
 end
 
-foo 'foo', &:to_s
-
-target.method object.map do |arg|
-  arg * 2
-end
-
-# from ruby test/ruby/test_call.rb
-assert_nil(
-  (
-    'a'.sub! 'b' do
-    end&.foo do
-    end
-  )
-)
-
+# rubocop:enable Layout/ExtraSpacing
+# rubocop:enable Metrics/LineLength
+# rubocop:enable Metrics/ClassLength
 # rubocop:enable Lint/UnusedBlockArgument
 "
 `;

--- a/test/cases/blocks.rb
+++ b/test/cases/blocks.rb
@@ -1,123 +1,232 @@
 # frozen_string_literal: true
 
 # rubocop:disable Lint/UnusedBlockArgument
-
-loop { 1 }
-
-loop do
-  1
-end
-
-loop do
-  # foobar
-end
-
-port ENV.fetch('PORT') { 3000 }
-
-test 'foobar' do
-end
-
-te.st 'foobar' do
-end
-
-test 'foobar' do
-  foobar
-end
-
-te.st 'foobar' do
-  foobar
-end
-
-test 'foobar' do |bar|
-  bar.to_s
-end
-
-te.st 'foobar' do |bar|
-  bar.to_s
-end
-
-loop { super_super_super_super_super_super_super_super_super_super_super_super_long }
-
-loop do
-  super_super_super_super_super_super_super_super_super_super_super_long
-end
-
-loop { |i| 1 }
-
-loop { |i; j| 1 }
-
-loop do |i|
-  i
-end
-
-loop { |*| i }
-
-loop { |(a, b)| i }
-
-loop { |a, (b, c), d, *e| i }
-
-loop { |i| super_super_super_super_super_super_super_super_super_super_super_super_long }
-
-loop do |i|
-  super_super_super_super_super_super_super_super_super_super_long
-end
-
+# rubocop:disable Metrics/ClassLength
 # rubocop:disable Metrics/LineLength
-define_method :long_method_name_that_forces_overflow do |_some_long_argument_that_overflows = Time.now,  _other_arg = nil|
-end
-# rubocop:enable Metrics/LineLength
+# rubocop:disable Layout/ExtraSpacing
 
-some_method.each do |foo|
-  bar
-  baz
-end.to_i
+class BlockTest < Minitest::Text
+  def test_inline_block
+    a = 0
+    test_method { a = 1 }
 
-[
-  super_super_super_super_super_super_super_super_super_super_long,
-  super_super_super_super_super_super_super_super_super_super_long
-].to_s
+    assert_equal a, 1
+  end
 
-{
-  a: 'super_super_super_super_super_super_super_super_super_super_long',
-  b: 'super_super_super_super_super_super_super_super_super_super_long'
-}.to_s
+  def test_multiline_block
+    a = 0
+    test_method do
+      a = 1
+    end
 
-loop { |i| i.to_s }
+    assert_equal a, 1
+  end
 
-loop do |i|
-  i.to_s
-end
+  def test_block_with_only_comment
+    result = test_method 'foo' do
+      # foobar
+    end
+    assert_equal result, 'foo'
+  end
 
-loop do |i|
-  i.to_s
-  i.next
-end
+  def test_block_with_parameters_and_inline_syntax
+    a = [1, 2, 3]
+    result = a.map { |el| el * 2 }
+    assert_equal result, [2, 4, 6]
+  end
 
-loop do |i|
-  i.to_s :db
-end
+  def test_block_with_parameters_and_do_end_syntax
+    a = [1, 2, 3]
+    result = a.map do |el|
+      el * 2
+    end
+    assert_equal result, [2, 4, 6]
+  end
 
-loop { |i, j| i.to_s }
+  def test_block_with_parameter_and_no_block_content
+    a = [1, 2, 3]
+    result = a.map { |*| }
+    assert_equal result, [nil, nil, nil]
+  end
 
-for i in [1, 2, 3] do
-  p i
-end
+  def test_block_with_parameters_four
+    arr = [[1, 2], [3, 4]]
+    result = arr.map { |(a, b)| a + b }
+    assert_equal result, [3, 7]
+  end
 
-def change
-  change_table :foo do
-    column :bar
+  def test_block_with_parameters_five
+    arr = [[1, [2, 3], 4, 5, 6, 7]]
+    result = arr.map { |a, (b, c), d, *e| "#{a}, #{b}, #{c}, #{d}, #{e}" }
+    assert_equal result, ['1, 2, 3, 4, [5, 6, 7]']
+  end
+
+  def test_block_with_method_call_one
+    arr = ['a', :b, 3]
+    result = arr.map { |i| i.to_s }
+    assert_equal result, %w[a b 3]
+  end
+
+  def test_block_with_method_call_two
+    arr = [[1, 2], [3, 4]]
+    result = arr.map { |i, j| i.to_s }
+    assert_equal result, [%w[1 2], %w[a b]]
+  end
+
+  loop { |i| 1 }
+
+  def test_block_with_only_parameter
+    result = test_method { |i| }
+    assert_equal result, ''
+  end
+
+  def test_block_with_method_call_three
+    arr = ['a', :b, 3]
+    result = arr.map do |i|
+      i.to_s
+    end
+    assert_equal result, %w[a b 3]
+  end
+
+  def test_block_with_method_call_four
+    arr = [1, 2, 3]
+    result = arr.map do |i|
+      i.to_s
+      i.next
+    end
+    assert_equal result, %w[a b c]
+  end
+
+  def test_blocks_with_parameters_and_long_contents_one
+    super_super_super_super_super_super_super_super_super_super_super_super_long = 'foo'
+    result = test_method { |x| super_super_super_super_super_super_super_super_super_super_super_super_long }
+
+    assert_equal result, 'foo'
+  end
+
+  def test_blocks_with_paramters_and_long_contents_two
+    super_super_super_super_super_super_super_super_super_super_super_long = 'foo'
+    blk = proc do |i|
+      super_super_super_super_super_super_super_super_super_super_super_long
+    end
+
+    result = blk.call
+
+    assert_equal result, 'foo'
+  end
+
+  def test_block_for_method
+    test_method 'foobar' do
+    end
+
+    test_method 'foobar' do
+      foobar
+    end
+
+    assert_equal true, true
+  end
+
+  def test_block_for_object
+    te.st 'foobar' do
+    end
+
+    te.st 'foobar' do
+      foobar
+    end
+
+    assert_equal true, true
+  end
+
+  def test_block_that_makes_a_call_to_the_parameter
+    test 'foobar' do |bar|
+      bar.to_s
+    end
+
+    te.st 'foobar' do |bar|
+      bar.to_s
+    end
+
+    assert_equal true, true
+  end
+
+  def test_block_with_symbol_proc
+    test_method(&:to_s)
+
+    assert_equal true, true
+  end
+
+  def test_blocks_with_long_contents
+    loop { super_super_super_super_super_super_super_super_super_super_super_super_long }
+
+    loop do
+      super_super_super_super_super_super_super_super_super_super_super_long
+    end
+
+    assert_equal true, true
+  end
+
+  def test_block_for_port
+    port ENV.fetch('PORT') { 3000 }
+  end
+
+  def test_really_long_method_and_parameter
+    define_method :long_method_name_that_forces_overflow do |_some_long_argument_that_overflows = Time.now, _other_arg = nil|
+    end
+
+    assert_equal true, true
+  end
+
+  def test_block_for_loop
+    arr = []
+
+    for i in [1, 2, 3] do
+      arr << i
+    end
+
+    assert_equal arr, [1, 2, 3]
+  end
+
+  # rubocop:disable Lint/NestedMethodDefinition
+  def test_block_in_method_definition
+    def change
+      test_method :foo do
+        column :bar
+      end
+    end
+
+    assert_equal true, true
+  end
+  # rubocop:enable Lint/NestedMethodDefinition
+
+  def test_foo_block
+    test_method 'foo' do |bar|
+      bar.to_s
+    end
+
+    assert_equal true, true
+  end
+
+  def test_complicated_method_with_block
+    target.method object.map do |arg|
+      arg * 2
+    end
+
+    assert_equal true, true
+  end
+
+  # from ruby test/ruby/test_call.rb
+  def test_call_block
+    assert_nil(('a'.sub! 'b' do end&.foo {}))
+  end
+
+  private
+
+  def test_method(arg = '')
+    yield arg
   end
 end
 
-foo 'foo' do |bar|
-  bar.to_s
-end
-
-target.method object.map do |arg|
-  arg * 2
-end
-
-# from ruby test/ruby/test_call.rb
-assert_nil(("a".sub! "b" do end&.foo {}))
-
+# rubocop:enable Layout/ExtraSpacing
+# rubocop:enable Metrics/LineLength
+# rubocop:enable Metrics/ClassLength
 # rubocop:enable Lint/UnusedBlockArgument


### PR DESCRIPTION
Add minitests for blocks.rb  …
Why:
We would like for the blocks.rb file for the test snapshots to also be a
minitest test so that we can run the ruby tests after the prettier
formatting process an validate that the assignments are equivalent post
formatting.

this commit:
Introduces minitest to '/test/cases/blocks.rb'

issue: [#120](#120)