### PR TITLE
Better handle string quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Better support string quotes by favoring what the user chose if the string contains escape patterns.
 
 ## [0.9.0] - 2019-03-18
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    prettier (0.8.0)
+    prettier (0.9.0)
 
 GEM
   remote: https://rubygems.org/

--- a/src/ripper.rb
+++ b/src/ripper.rb
@@ -353,12 +353,23 @@ module Layer
       base.attr_reader :source, :ending
     end
 
+    private
+
     def on___end__(body)
       @ending = super(source.split("\n")[lineno..-1].join("\n"))
     end
 
     def on_program(*body)
       super(*body).tap { |sexp| sexp[:body][0][:body] << ending if ending }
+    end
+  end
+
+  # Adds the used quote type onto string nodes.
+  module Strings
+    private
+
+    def on_tstring_end(quote)
+      last_sexp.merge!(quote: quote)
     end
   end
 end
@@ -405,6 +416,7 @@ class RipperJS < Ripper::SexpBuilder
   prepend Layer::Heredocs
   prepend Layer::Encoding
   prepend Layer::Ending
+  prepend Layer::Strings
 end
 
 if $0 == __FILE__

--- a/test/cases/__snapshots__/strings.test.js.snap
+++ b/test/cases/__snapshots__/strings.test.js.snap
@@ -4,11 +4,14 @@ exports[`strings.rb matches expected output 1`] = `
 "# frozen_string_literal: true
 
 # rubocop:disable Lint/UnneededCopDisableDirective
-# rubocop:disable Lint/Void, Layout/IndentHeredoc, Lint/UselessAssignment
-# rubocop:disable Layout/SpaceInsideStringInterpolation
-# rubocop:disable Lint/LiteralInInterpolation, Layout/ClosingHeredocIndentation
+
 # rubocop:disable Layout/ClosingParenthesisIndentation
+# rubocop:disable Layout/SpaceInsideStringInterpolation
+# rubocop:disable Lint/InterpolationCheck
+# rubocop:disable Lint/LiteralInInterpolation, Layout/ClosingHeredocIndentation
+# rubocop:disable Lint/Void, Layout/IndentHeredoc, Lint/UselessAssignment
 # rubocop:disable Style/StringLiteralsInInterpolation
+# rubocop:disable Style/UnneededInterpolation
 
 'a' # these are CHARs
 ?\\\\C-a
@@ -25,7 +28,15 @@ exports[`strings.rb matches expected output 1`] = `
 
 \\"abc\\\\n\\"
 
+'\\\\n'
+\\"\\\\n\\"
+'\\\\x0'
 \\"\\\\x0\\"
+'#{\\"\\\\n\\"}'
+\\"#{\\"\\\\n\\"}\\"
+\\"#{'\\\\n'}\\"
+\\"#{'\\\\n'}#{\\"\\\\n\\"}\\"
+\\"#{\\"\\\\n#{'\\\\n'}#{\\"\\\\n\\"}\\\\n\\"}#{'\\\\n'}\\"
 
 \\"\\\\M-\\\\C-a\\"
 
@@ -115,11 +126,14 @@ GRAND
 
 'abc \\"abc\\" abc'
 
-# rubocop:enable Lint/Void, Layout/IndentHeredoc, Lint/UselessAssignment
-# rubocop:enable Layout/SpaceInsideStringInterpolation
-# rubocop:enable Lint/LiteralInInterpolation, Layout/ClosingHeredocIndentation
 # rubocop:enable Layout/ClosingParenthesisIndentation
+# rubocop:enable Layout/SpaceInsideStringInterpolation
+# rubocop:enable Lint/InterpolationCheck
+# rubocop:enable Lint/LiteralInInterpolation, Layout/ClosingHeredocIndentation
+# rubocop:enable Lint/Void, Layout/IndentHeredoc, Lint/UselessAssignment
 # rubocop:enable Style/StringLiteralsInInterpolation
+# rubocop:enable Style/UnneededInterpolation
+
 # rubocop:enable Lint/UnneededCopDisableDirective
 "
 `;
@@ -128,11 +142,14 @@ exports[`strings.rb matches expected output 2`] = `
 "# frozen_string_literal: true
 
 # rubocop:disable Lint/UnneededCopDisableDirective
-# rubocop:disable Lint/Void, Layout/IndentHeredoc, Lint/UselessAssignment
-# rubocop:disable Layout/SpaceInsideStringInterpolation
-# rubocop:disable Lint/LiteralInInterpolation, Layout/ClosingHeredocIndentation
+
 # rubocop:disable Layout/ClosingParenthesisIndentation
+# rubocop:disable Layout/SpaceInsideStringInterpolation
+# rubocop:disable Lint/InterpolationCheck
+# rubocop:disable Lint/LiteralInInterpolation, Layout/ClosingHeredocIndentation
+# rubocop:disable Lint/Void, Layout/IndentHeredoc, Lint/UselessAssignment
 # rubocop:disable Style/StringLiteralsInInterpolation
+# rubocop:disable Style/UnneededInterpolation
 
 \\"a\\" # these are CHARs
 ?\\\\C-a
@@ -149,7 +166,15 @@ exports[`strings.rb matches expected output 2`] = `
 
 \\"abc\\\\n\\"
 
+'\\\\n'
+\\"\\\\n\\"
+'\\\\x0'
 \\"\\\\x0\\"
+'#{\\"\\\\n\\"}'
+\\"#{\\"\\\\n\\"}\\"
+\\"#{'\\\\n'}\\"
+\\"#{'\\\\n'}#{\\"\\\\n\\"}\\"
+\\"#{\\"\\\\n#{'\\\\n'}#{\\"\\\\n\\"}\\\\n\\"}#{'\\\\n'}\\"
 
 \\"\\\\M-\\\\C-a\\"
 
@@ -239,11 +264,14 @@ GRAND
 
 \\"abc \\\\\\"abc\\\\\\" abc\\"
 
-# rubocop:enable Lint/Void, Layout/IndentHeredoc, Lint/UselessAssignment
-# rubocop:enable Layout/SpaceInsideStringInterpolation
-# rubocop:enable Lint/LiteralInInterpolation, Layout/ClosingHeredocIndentation
 # rubocop:enable Layout/ClosingParenthesisIndentation
+# rubocop:enable Layout/SpaceInsideStringInterpolation
+# rubocop:enable Lint/InterpolationCheck
+# rubocop:enable Lint/LiteralInInterpolation, Layout/ClosingHeredocIndentation
+# rubocop:enable Lint/Void, Layout/IndentHeredoc, Lint/UselessAssignment
 # rubocop:enable Style/StringLiteralsInInterpolation
+# rubocop:enable Style/UnneededInterpolation
+
 # rubocop:enable Lint/UnneededCopDisableDirective
 "
 `;

--- a/test/cases/strings.rb
+++ b/test/cases/strings.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 # rubocop:disable Lint/UnneededCopDisableDirective
-# rubocop:disable Lint/Void, Layout/IndentHeredoc, Lint/UselessAssignment
-# rubocop:disable Layout/SpaceInsideStringInterpolation
-# rubocop:disable Lint/LiteralInInterpolation, Layout/ClosingHeredocIndentation
+
 # rubocop:disable Layout/ClosingParenthesisIndentation
+# rubocop:disable Layout/SpaceInsideStringInterpolation
+# rubocop:disable Lint/InterpolationCheck
+# rubocop:disable Lint/LiteralInInterpolation, Layout/ClosingHeredocIndentation
+# rubocop:disable Lint/Void, Layout/IndentHeredoc, Lint/UselessAssignment
 # rubocop:disable Style/StringLiteralsInInterpolation
+# rubocop:disable Style/UnneededInterpolation
 
 ?a # these are CHARs
 ?\C-a
@@ -22,7 +25,15 @@
 
 "abc\n"
 
+'\n'
+"\n"
+'\x0'
 "\x0"
+'#{"\n"}'
+"#{"\n"}"
+"#{'\n'}"
+"#{'\n'}#{"\n"}"
+"#{"\n#{'\n'}#{"\n"}\n"}#{'\n'}"
 
 "\M-\C-a"
 
@@ -114,9 +125,12 @@ GRAND
 
 'abc "abc" abc'
 
-# rubocop:enable Lint/Void, Layout/IndentHeredoc, Lint/UselessAssignment
-# rubocop:enable Layout/SpaceInsideStringInterpolation
-# rubocop:enable Lint/LiteralInInterpolation, Layout/ClosingHeredocIndentation
 # rubocop:enable Layout/ClosingParenthesisIndentation
+# rubocop:enable Layout/SpaceInsideStringInterpolation
+# rubocop:enable Lint/InterpolationCheck
+# rubocop:enable Lint/LiteralInInterpolation, Layout/ClosingHeredocIndentation
+# rubocop:enable Lint/Void, Layout/IndentHeredoc, Lint/UselessAssignment
 # rubocop:enable Style/StringLiteralsInInterpolation
+# rubocop:enable Style/UnneededInterpolation
+
 # rubocop:enable Lint/UnneededCopDisableDirective


### PR DESCRIPTION
In the case that a string contains an escape sequence, favor whichever quote the user chose. Closes #185.