### PR TITLE
Force method calls after blocks and xstrings to hang onto the end of the previous nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Force method calls after blocks and xstrings to hang onto the end of the previous nodes.
 
 ## [0.9.1] - 2019-03-24
 ### Changed

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -177,20 +177,6 @@ const nodes = {
 
     return concat(["break ", join(", ", path.call(print, "body", 0))]);
   },
-  call: (path, opts, print) => {
-    let name = path.getValue().body[2];
-
-    // You can call lambdas with a special syntax that looks like func.(*args).
-    // In this case, "call" is returned for the 3rd child node.
-    if (name !== "call") {
-      name = path.call(print, "body", 2);
-    }
-
-    return group(concat([
-      path.call(print, "body", 0),
-      indent(concat([softline, makeCall(path, opts, print), name]))
-    ]));
-  },
   case: (path, opts, print) => {
     const parts = ["case "];
 
@@ -602,6 +588,7 @@ module.exports = Object.assign(
   require("./nodes/alias"),
   require("./nodes/arrays"),
   require("./nodes/blocks"),
+  require("./nodes/calls"),
   require("./nodes/commands"),
   require("./nodes/conditionals"),
   require("./nodes/hooks"),

--- a/src/nodes/calls.js
+++ b/src/nodes/calls.js
@@ -1,0 +1,29 @@
+const { concat, group, indent, softline } = require("prettier").doc.builders;
+const { makeCall } = require("../utils");
+
+const noIndent = [
+  "method_add_block",
+  "xstring_literal"
+];
+
+module.exports = {
+  call: (path, opts, print) => {
+    const receiver = path.call(print, "body", 0);
+    const operator = makeCall(path, opts, print);
+    let name = path.getValue().body[2];
+
+    // You can call lambdas with a special syntax that looks like func.(*args).
+    // In this case, "call" is returned for the 3rd child node.
+    if (name !== "call") {
+      name = path.call(print, "body", 2);
+    }
+
+    // For certain left sides of the call nodes, we want to attach directly to
+    // the } or end.
+    if (noIndent.includes(path.getValue().body[0].type)) {
+      return concat([receiver, operator, name]);
+    }
+
+    return group(concat([receiver, indent(concat([softline, operator, name]))]));
+  }
+};

--- a/test/cases/__snapshots__/blocks.test.js.snap
+++ b/test/cases/__snapshots__/blocks.test.js.snap
@@ -60,6 +60,11 @@ define_method :long_method_name_that_forces_overflow do |_some_long_argument_tha
 end
 # rubocop:enable Metrics/LineLength
 
+some_method.each do |foo|
+  bar
+  baz
+end.to_i
+
 loop(&:to_s)
 
 loop(&:to_s)

--- a/test/cases/__snapshots__/strings.test.js.snap
+++ b/test/cases/__snapshots__/strings.test.js.snap
@@ -65,8 +65,10 @@ exports[`strings.rb matches expected output 1`] = `
 :\\"abc#{abc}abc\\"
 
 \`abc\`
-
 \`super_super_super_super_super_super_super_super_super_super_super_super_s_long\`
+\`
+  super_super_super_super_super_super_super_super_super_super_super_super_s_long
+\`.to_s
 
 <<-HERE
 This is a straight heredoc!
@@ -233,8 +235,10 @@ exports[`strings.rb matches expected output 2`] = `
 :\\"abc#{abc}abc\\"
 
 \`abc\`
-
 \`super_super_super_super_super_super_super_super_super_super_super_super_s_long\`
+\`
+  super_super_super_super_super_super_super_super_super_super_super_super_s_long
+\`.to_s
 
 <<-HERE
 This is a straight heredoc!

--- a/test/cases/blocks.rb
+++ b/test/cases/blocks.rb
@@ -65,6 +65,11 @@ define_method :long_method_name_that_forces_overflow do |_some_long_argument_tha
 end
 # rubocop:enable Metrics/LineLength
 
+some_method.each do |foo|
+  bar
+  baz
+end.to_i
+
 loop { |i| i.to_s }
 
 loop do |i|

--- a/test/cases/strings.rb
+++ b/test/cases/strings.rb
@@ -62,8 +62,8 @@
 :"abc#{abc}abc"
 
 %x[abc]
-
 %x[super_super_super_super_super_super_super_super_super_super_super_super_s_long]
+%x[super_super_super_super_super_super_super_super_super_super_super_super_s_long].to_s
 
 <<-HERE
 This is a straight heredoc!


### PR DESCRIPTION
Fixes #216