### PR TITLE
enable string symbol keys in hashes

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -84,6 +84,16 @@ const nodes = {
           parts.push(concat([printedLabel, " =>"]));
         }
         break;
+      case "dyna_symbol":
+        if (preferHashLabels) {
+          parts.push(concat(
+            printedLabel.parts.slice(1) // get rid of the : at the start
+              .concat(":"),
+          ));
+        } else {
+          parts.push(concat([printedLabel, " =>"]));
+        }
+        break;
       default:
         parts.push(concat([printedLabel, " =>"]));
         break;
@@ -245,7 +255,7 @@ const nodes = {
   dyna_symbol: (path, opts, print) => {
     const { quote } = path.getValue().body[0];
 
-    return concat([`:${quote}`, concat(path.call(print, "body", 0)), quote]);
+    return concat([":", quote, concat(path.call(print, "body", 0)), quote]);
   },
   else: (path, opts, print) => {
     const stmts = path.getValue().body[0];

--- a/src/ripper.rb
+++ b/src/ripper.rb
@@ -377,6 +377,11 @@ module Layer
     def on_tstring_end(quote)
       last_sexp.merge!(quote: quote)
     end
+
+    def on_label_end(quote)
+      # `quote` is ": or ':
+      last_sexp.merge!(quote: quote[0])
+    end
   end
 end
 

--- a/test/cases/__snapshots__/string_symbol_key.test.js.snap
+++ b/test/cases/__snapshots__/string_symbol_key.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`string_symbol_key.rb matches expected output 1`] = `
+"# frozen_string_literal: true
+
+# rubocop:disable Lint/UnneededCopDisableDirective
+# rubocop:disable Style/SymbolLiteral
+
+def foo
+  {
+    'test': 1,
+    'special-key': 2,
+    \\"double-quote\\": 3,
+    \\"#{1 + 1}\\": 4,
+    \\"non-hash-label\\": 5
+  }
+end
+
+# rubocop:enable Style/SymbolLiteral
+# rubocop:enable Lint/UnneededCopDisableDirective
+"
+`;
+
+exports[`string_symbol_key.rb matches expected output 2`] = `
+"# frozen_string_literal: true
+
+# rubocop:disable Lint/UnneededCopDisableDirective
+# rubocop:disable Style/SymbolLiteral
+
+def foo
+  {
+    :'test' => 1,
+    :'special-key' => 2,
+    :\\"double-quote\\" => 3,
+    :\\"#{1 + 1}\\" => 4,
+    :\\"non-hash-label\\" => 5
+  }
+end
+
+# rubocop:enable Style/SymbolLiteral
+# rubocop:enable Lint/UnneededCopDisableDirective
+"
+`;

--- a/test/cases/string_symbol_key.rb
+++ b/test/cases/string_symbol_key.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# rubocop:disable Lint/UnneededCopDisableDirective
+# rubocop:disable Style/SymbolLiteral
+
+def foo
+  {
+    'test': 1,
+    'special-key': 2,
+    "double-quote": 3,
+    "#{1 + 1}": 4,
+    :"non-hash-label" => 5
+  }
+end
+
+# rubocop:enable Style/SymbolLiteral
+# rubocop:enable Lint/UnneededCopDisableDirective

--- a/test/cases/string_symbol_key.test.js
+++ b/test/cases/string_symbol_key.test.js
@@ -1,0 +1,2 @@
+runCase("string_symbol_key.rb");
+runCase("string_symbol_key.rb", { preferHashLabels: false }, "hash-rockets.yml");


### PR DESCRIPTION
For some reason, the parser classes `:'x'` as an `xstring`, but the key
part of { 'x': 1 } as a string. That also, for some reason, meant the
the `on_tstring_end` in the parser was not adding the relevant quote to
the sexp.

I added a very similar function to the parser, but for labels. All the
existing tests pass. I don't think there is a clean way of determining
when/where we can strip quotes from the keys, so I've had to disable the
linter to stop errors when running in hash rocket mode.

Fixes a regression from bf11b5e90753ca918baddee07a3c8020d8ef40d2
Closes #242