### PR TITLE
Fix regex comment crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Alignment of command calls with arguments is fixed.
 - Alignment of `to` is explicitly allowed to not indent to better support rspec. (Thanks to @aaronjensen for the report.)
 - Fix up the `to_proc` transform so that it works with other argument handling appropriately.
+- Fixed regression on regexp comments.
 
 ## [0.10.0] - 2019-03-25
 ### Added

--- a/src/nodes/regexp.js
+++ b/src/nodes/regexp.js
@@ -5,6 +5,7 @@ module.exports = {
   regexp: makeList,
   regexp_literal: (path, opts, print) => {
     const [contents, ending] = path.map(print, "body");
+
     const useBraces = contents.some(content => typeof content === "string" && content.includes("/"));
     const parts = [useBraces ? "%r{" : "/"].concat(contents).concat([useBraces ? "}" : "/", ending.slice(1)]);
 

--- a/src/ripper.rb
+++ b/src/ripper.rb
@@ -250,6 +250,7 @@ module Layer
       break: [:body, 0],
       command: [:body, 1],
       command_call: [:body, 3],
+      regexp_literal: [:body, 0],
       string_literal: [:body, 0]
     }
 


### PR DESCRIPTION
Fixes #182 

Note that I'm not actually happy about the way the output looks with this, but it's good enough for now until we refactor comment handling.