### PR TITLE
Build prettier executables as part of 'rake build'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /yarn-error.log
 /pkg/
 *.gem
+exe/nodejs/*

--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,11 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/rb/**/*_test.rb']
 end
 
+desc 'Build executable files for Prettier'
+task :pkg do
+  sh 'yarn && yarn build'
+end
+
+task build: :pkg
+
 task default: :test

--- a/lib/prettier.rb
+++ b/lib/prettier.rb
@@ -8,7 +8,7 @@ module Prettier
 
   class << self
     def run(args)
-      prettier = File.expand_path(File.join('..', 'pkg', target), __dir__)
+      prettier = File.expand_path(File.join('../exe/nodejs', target), __dir__)
       plugin = File.expand_path(File.join('..'), __dir__)
       quoted = args.map { |arg| arg.start_with?('-') ? arg : "'#{arg}'" }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "prettier plugin for the Ruby programming language",
   "main": "src/ruby.js",
   "scripts": {
-    "build": "pkg --output pkg/prettier --targets=linux,macos,win node_modules/prettier/bin-prettier.js",
+    "build": "pkg --output exe/nodejs/prettier --targets=linux,macos,win node_modules/prettier/bin-prettier.js",
     "lint": "eslint --cache .",
     "print": "prettier --plugin=.",
     "rubocop": "run() { prettier --plugin=. $@ | bundle exec rubocop --stdin $1; }; run",

--- a/prettier.gemspec
+++ b/prettier.gemspec
@@ -16,10 +16,15 @@ Gem::Specification.new do |spec|
     Dir.chdir(File.expand_path('..', __FILE__)) do
       `git ls-files -z`.split("\x0").select do |f|
         f.match(
-          /^(bin|exe|src|CHANGELOG.md|package.json|yarn.lock|.rubocop.yml)/
+          /^(bin|exe|src|lib|CHANGELOG.md|package.json|yarn.lock|.rubocop.yml)/
         )
       end
-    end
+    end +
+      %w[
+        exe/nodejs/prettier-linux
+        exe/nodejs/prettier-macos
+        exe/nodejs/prettier-win.exe
+      ]
 
   spec.bindir = 'exe'
   spec.executables = 'rbprettier'


### PR DESCRIPTION
This is an attempt to build self-contained executables for Prettier as part of the `rake build` task so these executables will ship with a `.gem` package file when cutting a new version. This way the user no longer has to install Node.js dependencies just to run Prettier Ruby.

One issue with this approach is that the file size of each executable file exceeds +50MB and even the compressed tarball could take +47MB of disk space. Obviously you don't need all of three but just one, but I couldn't figure out a way to release each version for each platform (pretty sure Rubygems has this built-in). I wasn't sure if this is something we could iterate on (so is okay to merge this PR), or something that should be solved as part of this PR.

Let me know what you think!