### PR TITLE
Fix NoMethodError in on_method_add_block.

### DIFF
--- a/src/ripper.rb
+++ b/src/ripper.rb
@@ -502,7 +502,7 @@ class RipperJS < Ripper
 
       def on_method_add_block(method_add_arg, block)
         fcall, args = method_add_arg[:body]
-        
+
         # `method_add_arg[:body]` can be empty
         fcall ||= {}
         args ||= {}

--- a/src/ripper.rb
+++ b/src/ripper.rb
@@ -502,6 +502,10 @@ class RipperJS < Ripper
 
       def on_method_add_block(method_add_arg, block)
         fcall, args = method_add_arg[:body]
+        
+        # `method_add_arg[:body]` can be empty
+        fcall ||= {}
+        args ||= {}
 
         # If there are arguments to the `lambda`, that means `lambda` has been
         # overridden as a function so we cannot transform it into a `lambda`


### PR DESCRIPTION
`method_add_arg[:body]` can be empty, which can cause a "NoMethodError" when checking the extracted parts.