### PR TITLE
Calling `super` with a block and no args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [Unreleased]
 ### Changed
 - If a lambda literal is nested under a `command` or `command_call` node anywhere in the heirarchy, then it needs to use the higher-precedence `{ ... }` braces as opposed to the `do ... end` delimiters.
+- Calling `super` with a block and no args was causing the parser to fail when attempting to inspect lambda nodes. (Thanks to @jpickwell for the report.)
 
 ## [0.12.0] - 2019-04-18
 ### Added

--- a/src/ripper.rb
+++ b/src/ripper.rb
@@ -500,8 +500,13 @@ class RipperJS < Ripper
     Module.new do
       private
 
-      def on_method_add_block(method_add_arg, block)
-        fcall, args = method_add_arg[:body]
+      def on_method_add_block(invocation, block)
+        # It's possible to hit a `method_add_block` node without going through
+        # `method_add_arg` node, ex: `super {}`. In that case we're definitely
+        # not going to transform into a lambda.
+        return super if invocation[:type] != :method_add_arg
+
+        fcall, args = invocation[:body]
 
         # If there are arguments to the `lambda`, that means `lambda` has been
         # overridden as a function so we cannot transform it into a `lambda`

--- a/test/js/lambda.test.js
+++ b/test/js/lambda.test.js
@@ -102,5 +102,9 @@ describe("lambda", () => {
     test("does not transform overridden lambda", () => (
       expect("lambda(foo) { foo }").toMatchFormat()
     ));
+
+    test("does not break on super", () => (
+      expect("super {}").toMatchFormat()
+    ));
   });
 });


### PR DESCRIPTION
Was causing the parser to fail when attempting to inspect lambda nodes.

Fixes https://github.com/prettier/plugin-ruby/pull/278