### PR TITLE
fix(all-contributors): fix author search link by fixing projectOwner

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,6 +1,6 @@
 {
   "projectName": "plugin-ruby",
-  "projectOwner": "kddeisz",
+  "projectOwner": "prettier",
   "repoType": "github",
   "repoHost": "https://github.com",
   "files": [


### PR DESCRIPTION
The current configuration lead to author search links (when clicking on the emoji key under the avatar picture) like https://github.com/kddeisz/plugin-ruby/commits?author=kddeisz which link to a non existing GitHub repo (maybe previous name?). 

I fixed the `projectOwner` in `.all-contributorsrc`, which should lead to theses links being generated correctly.

PS: Thanks for including me in the list with the little contribution I added. Always nice to get notifications about this :)