### PR TITLE
Handle empty if statement gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ end
 
 (Thanks to @jakeprime for the report.)
 
+- Empty `if`, and `unless` conditionals are now handled gracefully:
+
+<!-- prettier-ignore -->
+```ruby
+if foo?
+end
+```
+
+(Thanks to @AlanFoster for the fix, and @jamescostian for the report.)
+
 ## [0.15.0] - 2019-08-06
 
 ### Changed

--- a/src/nodes/conditionals.js
+++ b/src/nodes/conditionals.js
@@ -177,6 +177,20 @@ const printConditional = keyword => (path, { inlineConditionals }, print) => {
     return group(printWithAddition(keyword, path, print, { breaking: true }));
   }
 
+  // Explicitly handling the scenario of an empty conditional body, which can't be inlined
+  // as it produces invalid ruby code
+  const [_predicate, stmts] = path.getValue().body;
+  const isEmptyConditionalBody =
+    stmts.type === "stmts" && stmts.body[0].type === "void_stmt";
+
+  if (isEmptyConditionalBody) {
+    return concat([
+      `${keyword} `,
+      align(keyword.length + 1, path.call(print, "body", 0)),
+      concat([hardline, "end"])
+    ]);
+  }
+
   return printSingle(keyword)(path, { inlineConditionals }, print);
 };
 

--- a/test/js/conditionals.test.js
+++ b/test/js/conditionals.test.js
@@ -43,6 +43,15 @@ describe("conditionals", () => {
       test("empty first body", () => {
         const content = ruby(`
           ${keyword} a
+          end
+        `);
+
+        return expect(content).toMatchFormat();
+      });
+
+      test("empty first body with present second body", () => {
+        const content = ruby(`
+          ${keyword} a
 
           else
             b
@@ -125,6 +134,15 @@ describe("conditionals", () => {
         }));
 
       test("empty first body", () => {
+        const content = ruby(`
+          ${keyword} a
+          end
+        `);
+
+        return expect(content).toMatchFormat({ inlineConditionals: false });
+      });
+
+      test("empty first body with present second body", () => {
         const content = ruby(`
           ${keyword} a
 


### PR DESCRIPTION
Closes #390

## Input

```rb
def setup_security_settings!
  if SecuritySettings.count == 0
  end
end
```

## Before

The conditional was converted into the `if_mod` form via a call to `printSingle`

```rb
def setup_security_settings!
   if SecuritySettings.count == 0
end
```

## After

The empty body scenario is now handled explicitly:

```rb
def setup_security_settings!
  if SecuritySettings.count == 0
  end
end
```