### PR TITLE
Handle nil body for ignored nl scanner event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ end
 
 (Thanks to @AlanFoster for the fix, and @jamescostian for the report.)
 
+- Fix nil body edge case when handling ruby's internal `ignored_nl` scanner event. (Thanks to @AlanFoster.)
+
 ## [0.15.0] - 2019-08-06
 
 ### Changed

--- a/src/ripper.rb
+++ b/src/ripper.rb
@@ -340,7 +340,9 @@ class RipperJS < Ripper
       (SCANNER_EVENTS - defined).each do |event|
         define_method(:"on_#{event}") do |body|
           super(body).tap do |node|
-            node.merge!(char_start: char_pos, char_end: char_pos + body.size)
+            node.merge!(
+              char_start: char_pos, char_end: char_pos + body.to_s.size
+            )
 
             scanner_events << node
           end

--- a/test/js/comments.test.js
+++ b/test/js/comments.test.js
@@ -159,6 +159,16 @@ describe("comments", () => {
 
     test("command calls", () =>
       expect("command.call 'foo' # this is an inline comment").toMatchFormat());
+
+    test("chained command calls with comments", () => {
+      const content = ruby(`
+        puts foo
+          .bar # comment
+          .baz
+      `);
+
+      return expect(content).not.toFailFormat();
+    });
   });
 
   describe("arrays", () => {


### PR DESCRIPTION
## Before

Given the input:

```rb
puts foo
    .bar # comment
    .baz
```

The following crash was observed:

```
prettier/index.js:10645
    throw error.stack;
    ^
Error: /Users/user/Documents/code/plugin-ruby/src/ripper.rb:343:in `block (4 levels) in <class:RipperJS>': undefined method `size' for nil:NilClass (NoMethodError)
```

This was being lexed by Ripper as having a nil body for the `on_ignored_nl` event:

```rb
[[[1, 0], :on_ident, "puts", EXPR_CMDARG],
 [[1, 4], :on_sp, " ", EXPR_CMDARG],
 [[1, 5], :on_ident, "foo", EXPR_ARG],
 [[1, 8], :on_ignored_nl, nil, EXPR_ARG],
 [[1, 8], :on_ignored_nl, "\n", EXPR_ARG],
 [[2, 0], :on_sp, "  ", EXPR_ARG],
 [[2, 2], :on_period, ".", EXPR_DOT],
 [[2, 3], :on_ident, "bar", EXPR_ARG],
 [[2, 6], :on_sp, " ", EXPR_ARG],
 [[2, 7], :on_comment, "# comment\n", EXPR_ARG],
 [[3, 0], :on_sp, "  ", EXPR_ARG],
 [[3, 2], :on_period, ".", EXPR_DOT],
 [[3, 3], :on_ident, "baz", EXPR_ARG],
 [[3, 6], :on_nl, "\n", EXPR_BEG]]
```

## After

The comment handling still isn't right IMO, but there are no errors:

```rb
puts foo.bar.baz # comment
```