### PR TITLE
Add internal lex tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 
+- [INTERNAL] Add `bin/lex` for viewing the tokenized result of Ripper on Ruby code (Thanks to @AlanFoster.)
 - When predicates from within an `if`, `unless`, `while`, or `until` loop break the line, they should be aligned together. For example,
 
 <!-- prettier-ignore -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,18 @@ yarn run test
 yarn run test -u
 ```
 
+**Viewing the tokenized result of Ripper on code**
+
+```
+bin/lex 'your_ruby_code(1, 2, 3)'
+```
+
+**Viewing the tokenized result of Ripper on a file**
+
+```
+bin/lex file.rb
+```
+
 **Viewing the output of RipperJS on a file**
 
 ```

--- a/bin/lex
+++ b/bin/lex
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require 'ripper'
+
+source = File.file?(ARGV[0]) ? File.read(ARGV[0]) : ARGV[0].gsub('\\n', "\n")
+pp Ripper.lex(source)


### PR DESCRIPTION
Add `bin/lex` for viewing the tokenized result of Ripper on Ruby code.
I originally needed this functionality for: https://github.com/prettier/plugin-ruby/pull/406