### PR TITLE
Fixes for assigning expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,22 @@ cannot be translated into `[]:` as that is an invalid symbol. Instead, it stays 
 
 - Do not attempt to format the insides of xstring literals (string that get sent to the command line surrounded by backticks or `%x`). (Thanks to @cldevs for the report.)
 - When predicates for `if`, `unless`, `while`, or `until` nodes contain an assignment, we can't know for sure that it doesn't modify the body. In this case we need to always break and form a multi-line block. (Thanks to @cldevs for the report.)
+- When the return value of `if`, `unless`, `while`, or `until` nodes are assigned to anything other than a local variable, we need to wrap them in parentheses if we're changing to the modifier form. This is because the following expressions have different semantic meaning:
+
+<!-- prettier-ignore -->
+```ruby
+hash[:key] = break :value while false
+hash[:key] = while false do break :value end
+```
+
+The first one will not result in an empty hash, whereas the second one will result in `{ key: nil }`. In this case what we need to do for the first expression to align is wrap it in parens, as in:
+
+<!-- prettier-ignore -->
+```ruby
+hash[:key] = (break :value while false)
+```
+
+That will guarantee that the expressions are equivalent. (Thanks to @MarcManiez for the report.)
 
 ## [0.15.0] - 2019-08-06
 

--- a/src/nodes/loops.js
+++ b/src/nodes/loops.js
@@ -10,11 +10,30 @@ const {
 const { containsAssignment } = require("../utils");
 
 const printLoop = (keyword, modifier) => (path, { inlineLoops }, print) => {
-  const inlineLoop = concat([
+  let inlineParts = [
     path.call(print, "body", 1),
     ` ${keyword} `,
     path.call(print, "body", 0)
-  ]);
+  ];
+
+  // If the return value of this loop expression is being assigned to anything
+  // besides a local variable then we can't inline the entire expression
+  // without wrapping it in parentheses. This is because the following
+  // expressions have different semantic meaning:
+  //
+  //     hash[:key] = break :value while false
+  //     hash[:key] = while false do break :value end
+  //
+  // The first one will not result in an empty hash, whereas the second one
+  // will result in `{ key: nil }`. In this case what we need to do for the
+  // first expression to align is wrap it in parens, as in:
+  //
+  //     hash[:key] = (break :value while false)
+  if (["assign", "massign"].includes(path.getParentNode().type)) {
+    inlineParts = ["("].concat(inlineParts).concat(")");
+  }
+
+  const inlineLoop = concat(inlineParts);
 
   // If we're in the modifier form and we're modifying a `begin`, then this is a
   // special case where we need to explicitly use the modifier form because

--- a/test/js/conditionals.test.js
+++ b/test/js/conditionals.test.js
@@ -94,13 +94,18 @@ describe("conditionals", () => {
       test("align long predicates", () =>
         expect(`foo ${keyword} ${long} || ${long}a`).toChangeFormat(
           ruby(`
-          ${keyword} ${long} ||
-              ${Array(keyword.length)
-                .fill()
-                .join(" ")}${long}a
-            foo
-          end
-        `)
+            ${keyword} ${long} ||
+                ${Array(keyword.length)
+                  .fill()
+                  .join(" ")}${long}a
+              foo
+            end
+          `)
+        ));
+
+      test("wraps single lines in parens when assigning", () =>
+        expect(`hash[:key] = ${keyword} false then :value end`).toChangeFormat(
+          `hash[:key] = (:value ${keyword} false)`
         ));
     });
   });

--- a/test/js/loops.test.js
+++ b/test/js/loops.test.js
@@ -56,6 +56,11 @@ describe.each(["while", "until"])("%s", keyword => {
 
       return expect(content).toMatchFormat();
     });
+
+    test("wraps single lines in parens when assigning", () =>
+      expect(
+        `hash[:key] = ${keyword} false do break :value end`
+      ).toChangeFormat(`hash[:key] = (break :value ${keyword} false)`));
   });
 
   describe("inlines not allowed", () => {


### PR DESCRIPTION
When assigning the return of an `if`, `unless`, `while`, or `until`, we need to take special care to wrap them in parentheses if they are going to use the modifier form. Fixes #410.