### PR TITLE
Better interpolation in heredocs.

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -259,6 +259,15 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "eins78",
+      "name": "Max Albrecht",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/134942?v=4",
+      "profile": "http://178.is",
+      "contributions": [
+        "bug"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -250,6 +250,15 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "joeyjoejoejr",
+      "name": "Joe Jackson",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/1141502?v=4",
+      "profile": "https://github.com/joeyjoejoejr",
+      "contributions": [
+        "bug"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ end
 
 the previous expression was being transformed into a ternary which was invalid ruby. Instead it now stays broken out into an if/else block. (Thanks to @jamescostian for the report.)
 
+- Better support for embedded expressions inside heredocs. For example,
+
+<!-- prettier-ignore -->
+```ruby
+<<-HERE
+  foo bar baz
+  #{qux}
+  foo bar baz
+HERE
+
+should remain formatted as it is. Whereas previously due to the way the lines were split, you would sometimes end up with it breaking after `#{`. (Thanks to @localhostdotdev, @joeyjoejoejr, and @eins78 for the reports.)
+
 ## [0.15.1] - 2019-11-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://twitter.com/github0013"><img src="https://avatars0.githubusercontent.com/u/809378?v=4" width="100px;" alt="github0013"/><br /><sub><b>github0013</b></sub></a><br /><a href="https://github.com/prettier/plugin-ruby/issues?q=author%3Agithub0013" title="Bug reports">🐛</a></td>
     <td align="center"><a href="https://jami.am"><img src="https://avatars1.githubusercontent.com/u/1456118?v=4" width="100px;" alt="James Costian"/><br /><sub><b>James Costian</b></sub></a><br /><a href="https://github.com/prettier/plugin-ruby/issues?q=author%3Ajamescostian" title="Bug reports">🐛</a></td>
     <td align="center"><a href="https://github.com/joeyjoejoejr"><img src="https://avatars0.githubusercontent.com/u/1141502?v=4" width="100px;" alt="Joe Jackson"/><br /><sub><b>Joe Jackson</b></sub></a><br /><a href="https://github.com/prettier/plugin-ruby/issues?q=author%3Ajoeyjoejoejr" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="http://178.is"><img src="https://avatars3.githubusercontent.com/u/134942?v=4" width="100px;" alt="Max Albrecht"/><br /><sub><b>Max Albrecht</b></sub></a><br /><a href="https://github.com/prettier/plugin-ruby/issues?q=author%3Aeins78" title="Bug reports">🐛</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -191,12 +191,12 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="http://www.cldevs.com"><img src="https://avatars3.githubusercontent.com/u/38632061?v=4" width="100px;" alt="CL Web Developers"/><br /><sub><b>CL Web Developers</b></sub></a><br /><a href="https://github.com/prettier/plugin-ruby/issues?q=author%3Acldevs" title="Bug reports">🐛</a></td>
     <td align="center"><a href="https://twitter.com/github0013"><img src="https://avatars0.githubusercontent.com/u/809378?v=4" width="100px;" alt="github0013"/><br /><sub><b>github0013</b></sub></a><br /><a href="https://github.com/prettier/plugin-ruby/issues?q=author%3Agithub0013" title="Bug reports">🐛</a></td>
     <td align="center"><a href="https://jami.am"><img src="https://avatars1.githubusercontent.com/u/1456118?v=4" width="100px;" alt="James Costian"/><br /><sub><b>James Costian</b></sub></a><br /><a href="https://github.com/prettier/plugin-ruby/issues?q=author%3Ajamescostian" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="https://github.com/joeyjoejoejr"><img src="https://avatars0.githubusercontent.com/u/1141502?v=4" width="100px;" alt="Joe Jackson"/><br /><sub><b>Joe Jackson</b></sub></a><br /><a href="https://github.com/prettier/plugin-ruby/issues?q=author%3Ajoeyjoejoejr" title="Bug reports">🐛</a></td>
   </tr>
 </table>
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/src/nodes/strings.js
+++ b/src/nodes/strings.js
@@ -4,7 +4,9 @@ const {
   hardline,
   indent,
   literalline,
-  softline
+  softline,
+  line,
+  join
 } = require("../prettier");
 const { concatBody, empty, makeList, prefix, surround } = require("../utils");
 const escapePattern = require("../escapePattern");
@@ -61,6 +63,53 @@ const makeString = (content, enclosingQuote, originalQuote) => {
   });
 };
 
+// The `parts` argument that comes into this function is an array of either
+// printed embedded expressions or plain strings (that themselves can contain
+// newlines). What we want to return is an array where each element represents a
+// line in the original text. So we end up tracking every line as we go and
+// pushing onto a `currentLine` variable, then when we hit a new line we push
+// the current line onto the `lines` variable until we've used up every part.
+const makeHeredocLines = parts => {
+  let lines = [];
+  let currentLine = [];
+
+  parts.forEach(part => {
+    if (part.type === "group" || !part.includes("\n")) {
+      // In this case we've either hit an embedded expression or the piece of
+      // the current line that we're looking at is in the middle of two of them,
+      // so we just push onto the current line and continue on.
+      currentLine.push(part);
+      return;
+    }
+
+    let splits = part.split("\n");
+    if (splits[splits.length - 1] === "") {
+      // If a line ends with a newline, then we end up with an empty string at
+      // the end of the splits, we just pop it off here since we'll handle the
+      // newlines later.
+      splits = splits.slice(0, -1);
+    }
+
+    if (currentLine.length > 0) {
+      lines.push(concat(currentLine.concat(splits[0])));
+      currentLine = [];
+    } else {
+      lines.push(splits[0]);
+    }
+
+    if (splits.length > 1) {
+      lines = lines.concat(splits.slice(1, -1));
+      currentLine.push(splits[splits.length - 1]);
+    }
+  });
+
+  if (currentLine.length > 0) {
+    lines = lines.concat(currentLine);
+  }
+
+  return lines;
+};
+
 module.exports = {
   "@CHAR": (path, { preferSingleQuotes }, _print) => {
     const { body } = path.getValue();
@@ -79,12 +128,9 @@ module.exports = {
   },
   heredoc: (path, opts, print) => {
     const { beging, ending } = path.getValue();
+    const lines = makeHeredocLines(path.map(print, "body"));
 
-    return concat([
-      beging,
-      concat([literalline].concat(path.map(print, "body"))),
-      ending
-    ]);
+    return concat([beging, literalline, join(literalline, lines), literalline, ending]);
   },
   string: makeList,
   string_concat: (path, opts, print) =>

--- a/src/nodes/strings.js
+++ b/src/nodes/strings.js
@@ -5,7 +5,6 @@ const {
   indent,
   literalline,
   softline,
-  line,
   join
 } = require("../prettier");
 const { concatBody, empty, makeList, prefix, surround } = require("../utils");
@@ -130,7 +129,13 @@ module.exports = {
     const { beging, ending } = path.getValue();
     const lines = makeHeredocLines(path.map(print, "body"));
 
-    return concat([beging, literalline, join(literalline, lines), literalline, ending]);
+    return concat([
+      beging,
+      literalline,
+      join(literalline, lines),
+      literalline,
+      ending
+    ]);
   },
   string: makeList,
   string_concat: (path, opts, print) =>

--- a/test/js/strings.test.js
+++ b/test/js/strings.test.js
@@ -178,6 +178,20 @@ describe("strings", () => {
 
         return expect(content).toMatchFormat();
       });
+
+      test("with embedded expressions", () => {
+        const content = ruby(`
+          <<-HERE
+            ${long}
+            ${long}
+            #{id}
+            ${long}
+            ${long}
+          HERE
+        `);
+
+        return expect(content).toMatchFormat();
+      });
     });
 
     describe("squiggly heredocs", () => {


### PR DESCRIPTION
Split up the string on newline, makes for a better experience.

Fixes #217, #394, and #398.