### PR TITLE
Fix up return node printing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
         "varsIgnorePattern": "^_"
       }
     ],
+    "prefer-destructuring": "off",
     "prefer-object-spread": "off",
     "prefer-spread": "off"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ HERE
 
 should remain formatted as it is. Whereas previously due to the way the lines were split, you would sometimes end up with it breaking after `#{`. (Thanks to @localhostdotdev, @joeyjoejoejr, and @eins78 for the reports.)
 
+- Fix up `return` node printing. When returning multiple values, you need to return an array literal as opposed to using parentheses. (Thanks to @jamescostian for the report.)
+
 ## [0.15.1] - 2019-11-05
 
 ### Changed

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -23,6 +23,7 @@ module.exports = Object.assign(
   require("./nodes/patterns"),
   require("./nodes/regexp"),
   require("./nodes/rescue"),
+  require("./nodes/return"),
   require("./nodes/scopes"),
   require("./nodes/statements"),
   require("./nodes/strings")

--- a/src/nodes/flow.js
+++ b/src/nodes/flow.js
@@ -1,11 +1,4 @@
-const {
-  concat,
-  group,
-  ifBreak,
-  indent,
-  join,
-  softline
-} = require("../prettier");
+const { concat, join } = require("../prettier");
 const { literal } = require("../utils");
 
 module.exports = {
@@ -42,32 +35,6 @@ module.exports = {
 
     return concat(["next ", join(", ", path.call(print, "body", 0))]);
   },
-  return: (path, opts, print) => {
-    const args = path.getValue().body[0].body[0];
-
-    if (!args) {
-      return "return";
-    }
-
-    let value = join(", ", path.call(print, "body", 0));
-
-    // If the body of the return contains parens, then just skip directly to the
-    // content of the parens so that we can skip printing parens if we don't
-    // want them.
-    if (args.body[0] && args.body[0].type === "paren") {
-      value = path.call(print, "body", 0, "body", 0, "body", 0, "body", 0);
-    }
-
-    return group(
-      concat([
-        "return",
-        ifBreak("(", " "),
-        indent(concat([softline, value])),
-        concat([softline, ifBreak(")", "")])
-      ])
-    );
-  },
-  return0: literal("return"),
   yield: (path, opts, print) => {
     if (path.getValue().body[0].type === "paren") {
       return concat(["yield", path.call(print, "body", 0)]);

--- a/src/nodes/return.js
+++ b/src/nodes/return.js
@@ -1,0 +1,60 @@
+const {
+  concat,
+  group,
+  ifBreak,
+  indent,
+  line,
+  join,
+  softline
+} = require("../prettier");
+const { literal } = require("../utils");
+
+const printReturn = (path, opts, print) => {
+  let args = path.getValue().body[0].body[0];
+  let steps = ["body", 0, "body", 0];
+
+  if (!args) {
+    return "return";
+  }
+
+  // If the body of the return contains parens, then just skip directly to the
+  // content of the parens so that we can skip printing parens if we don't
+  // want them.
+  if (args.body[0] && args.body[0].type === "paren") {
+    args = args.body[0].body[0];
+    steps = steps.concat("body", 0, "body", 0);
+  }
+
+  // If we're returning an array literal that isn't a special array, then we
+  // want to grab the arguments so that we can print them out as if they were
+  // normal return arguments.
+  if (
+    args.body[0] &&
+    args.body[0].type === "array" &&
+    ["args", "args_add_star"].includes(args.body[0].body[0].type)
+  ) {
+    steps = steps.concat("body", 0, "body", 0);
+  }
+
+  // Now that we've established which actual node is the arguments to return,
+  // we grab it out of the path by diving down the steps that we've set up.
+  const parts = path.call.apply(path, [print].concat(steps));
+
+  // If we got the value straight out of the parens, then `parts` would only
+  // be a singular doc as opposed to an array.
+  const value = Array.isArray(parts) ? join(concat([",", line]), parts) : parts;
+
+  return group(
+    concat([
+      "return",
+      ifBreak(parts.length > 1 ? " [" : "(", " "),
+      indent(concat([softline, value])),
+      concat([softline, ifBreak(parts.length > 1 ? "]" : ")", "")])
+    ])
+  );
+};
+
+module.exports = {
+  return: printReturn,
+  return0: literal("return")
+};

--- a/test/js/return.test.js
+++ b/test/js/return.test.js
@@ -14,4 +14,25 @@ describe("return", () => {
 
   test("return with breaking", () =>
     expect(`return ${long}`).toChangeFormat(`return(\n  ${long}\n)`));
+
+  test("returning an array", () =>
+    expect("return [1, 2, 3]").toChangeFormat("return 1, 2, 3"));
+
+  test("returning a list that breaks", () =>
+    expect(`return ${long}, ${long}`).toChangeFormat(
+      `return [\n  ${long},\n  ${long}\n]`
+    ));
+
+  test("returning an array within parens", () =>
+    expect("return([1, 2, 3])").toChangeFormat("return 1, 2, 3"));
+
+  test("returning a long special array", () =>
+    expect(`return %w[${long}]`).toChangeFormat(
+      `return(\n  %w[\n    ${long}\n  ]\n)`
+    ));
+
+  test("returning two arguments, one that breaks", () =>
+    expect(`return foo, ${long}`).toChangeFormat(
+      `return [\n  foo,\n  ${long}\n]`
+    ));
 });


### PR DESCRIPTION
When returning multiple values from a return, you need to return using an array, not parens.

Fixes #386