### PR TITLE
Fixes return node for arrays

### DIFF
--- a/src/nodes/return.js
+++ b/src/nodes/return.js
@@ -25,12 +25,14 @@ const printReturn = (path, opts, print) => {
     steps = steps.concat("body", 0, "body", 0);
   }
 
-  // If we're returning an array literal that isn't a special array, then we
-  // want to grab the arguments so that we can print them out as if they were
-  // normal return arguments.
+  // If we're returning an array literal that isn't a special array, single
+  // element array, or an empty array, then we want to grab the arguments so
+  // that we can print them out as if they were normal return arguments.
   if (
     args.body[0] &&
     args.body[0].type === "array" &&
+    args.body[0].body[0] &&
+    args.body[0].body[0].body.length > 1 &&
     ["args", "args_add_star"].includes(args.body[0].body[0].type)
   ) {
     steps = steps.concat("body", 0, "body", 0);

--- a/test/js/return.test.js
+++ b/test/js/return.test.js
@@ -18,6 +18,11 @@ describe("return", () => {
   test("returning an array", () =>
     expect("return [1, 2, 3]").toChangeFormat("return 1, 2, 3"));
 
+  test("returning an empty array", () => expect("return []").toMatchFormat());
+
+  test("returning a single element array", () =>
+    expect("return [1]").toMatchFormat());
+
   test("returning a list that breaks", () =>
     expect(`return ${long}, ${long}`).toChangeFormat(
       `return [\n  ${long},\n  ${long}\n]`


### PR DESCRIPTION
I took a pass at fixing for my own use.  I tried to make the minimum changes required.

| Original | Before | After |
|---- |----|----|
| `return [1, 2, 3]` | `return 1, 2, 3` | `return 1, 2, 3` |
| `return [1]` | `return 1` | `return [1]` |
| `return []`| `TypeError` | `return []`|