### PR TITLE
Increase spawnSync maxBuffer to 10MB

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -3,7 +3,8 @@ const path = require("path");
 
 module.exports = (text, _parsers, _opts) => {
   const child = spawnSync("ruby", [path.join(__dirname, "./ripper.rb")], {
-    input: text
+    input: text,
+    maxBuffer: 10 * 1024 * 1024 // 10MB
   });
 
   const error = child.stderr.toString();


### PR DESCRIPTION
This PR fix https://github.com/prettier/plugin-ruby/issues/450

spawnSync maxBuffer default is 1MB. https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options

but that buffer is not enough to output big size ruby code.
