### PR TITLE
Change underscore number formatting to act only on 5+ digit numbers

### DIFF
--- a/src/nodes/ints.js
+++ b/src/nodes/ints.js
@@ -11,7 +11,7 @@ module.exports = {
     // If the number is a base 10 number, is sufficiently large, and is not
     // already formatted with underscores, then add them in in between the
     // numbers every three characters starting from the right.
-    if (!body.startsWith("0") && body.length >= 4 && !body.includes("_")) {
+    if (!body.startsWith("0") && body.length >= 5 && !body.includes("_")) {
       return `  ${body}`
         .slice((body.length + 2) % 3)
         .match(/.{3}/g)

--- a/test/js/numbers.test.js
+++ b/test/js/numbers.test.js
@@ -6,6 +6,9 @@ describe("numbers", () => {
   test("auto adds o for octal numbers", () =>
     expect("0123").toChangeFormat("0o123"));
 
+  test("does not consider numbers large until they have more than 4 digits", () =>
+    expect("1234").toMatchFormat());
+
   test("for large numbers adds underscores (mod 3 ==== 0)", () =>
     expect("123456").toChangeFormat("123_456"));
 


### PR DESCRIPTION
Fixes #464 

This commit changes the amount of digits that a number must have before
it is automatically formatted with underscores.

The previous implementation would format "1024" as "1_024" which had
readability issues with dates.