### PR TITLE
no line break for aref node

### DIFF
--- a/src/nodes/arrays.js
+++ b/src/nodes/arrays.js
@@ -34,13 +34,8 @@ const printAref = (path, opts, print) =>
     concat([
       path.call(print, "body", 0),
       "[",
-      indent(
-        concat([
-          softline,
-          join(concat([",", line]), path.call(print, "body", 1))
-        ])
-      ),
-      concat([softline, "]"])
+      join(concat([",", line]), path.call(print, "body", 1)),
+      "]"
     ])
   );
 


### PR DESCRIPTION
right now, it will convert code

```
hello.foo.bar.hello.foo.bar.hello.foo.bar.hello.foo.bar.hello.foo.bar.hello['test']
```

to

```
hello.foo.bar.hello.foo.bar.hello.foo.bar.hello.foo.bar.hello.foo.bar.hello[
  'test'
]
```

but I expect it to be

```
hello.foo.bar.hello.foo.bar.hello.foo.bar.hello.foo.bar.hello.foo.bar
  .hello['test']
```