### PR TITLE
does not transform single element arrays

### DIFF
--- a/src/nodes/arrays.js
+++ b/src/nodes/arrays.js
@@ -21,6 +21,8 @@ const isStringArray = args =>
 const isSymbolArray = args =>
   args.body.every(arg => arg.type === "symbol_literal");
 
+const isMultiElementsArray = args => args.body.length > 1;
+
 const makeArray = start => (path, opts, print) =>
   [start].concat(path.map(print, "body"));
 
@@ -89,13 +91,13 @@ module.exports = {
       return "[]";
     }
 
-    if (isStringArray(args)) {
+    if (isStringArray(args) && isMultiElementsArray(args)) {
       return printSpecialArray(
         ["%w"].concat(getSpecialArrayParts(path, print, args))
       );
     }
 
-    if (isSymbolArray(args)) {
+    if (isSymbolArray(args) && isMultiElementsArray(args)) {
       return printSpecialArray(
         ["%i"].concat(getSpecialArrayParts(path, print, args))
       );

--- a/test/js/array.test.js
+++ b/test/js/array.test.js
@@ -8,6 +8,9 @@ describe("array", () => {
   test("transforms basic string arrays", () =>
     expect("['a', 'b', 'c', 'd', 'e']").toChangeFormat("%w[a b c d e]"));
 
+  test("does not transform single element arrays", () =>
+    expect("['a']").toMatchFormat());
+
   test("does not transform string arrays with spaces", () =>
     expect("['a', 'b c', 'd', 'e']").toMatchFormat());
 
@@ -16,6 +19,9 @@ describe("array", () => {
 
   test("transforms basic symbol arrays", () =>
     expect("[:a, :b, :c]").toChangeFormat("%i[a b c]"));
+
+  test("does not transforms single element arrays", () =>
+    expect("[:a]").toMatchFormat());
 
   test("does not transform symbol arrays with dynamic symbols", () =>
     expect("[:'a + b']").toMatchFormat());


### PR DESCRIPTION
it's a bit weird to forcibly convert single element arrays, like

`['test']` => '%w[test]'
`[:test]` => `%i[test]`

I prefer to keep single element arrays.