### PR TITLE
Improve perf by using --disable-gems

### DIFF
--- a/playground/ripper.rb
+++ b/playground/ripper.rb
@@ -1,14 +1,7 @@
 #!/usr/bin/env ruby
 
-REQUIRED_VERSION = Gem::Version.new('2.5')
-if Gem::Version.new(RUBY_VERSION) < REQUIRED_VERSION
-  warn(
-    "Ruby version #{RUBY_VERSION} not supported. " \
-      "Please upgrade to #{REQUIRED_VERSION} or above."
-  )
-
-  exit 1
-end
+require_relative './utils'
+Prettier::PluginRuby::Utils.ensure_compatible_ruby_version!
 
 require 'json' unless defined?(JSON)
 require 'ripper'

--- a/src/parse.js
+++ b/src/parse.js
@@ -2,7 +2,7 @@ const { spawnSync } = require("child_process");
 const path = require("path");
 
 module.exports = (text, _parsers, _opts) => {
-  const child = spawnSync("ruby", [path.join(__dirname, "./ripper.rb")], {
+  const child = spawnSync("ruby", ["--disable-gems", path.join(__dirname, "./ripper.rb")], {
     input: text,
     maxBuffer: 10 * 1024 * 1024 // 10MB
   });

--- a/src/ripper.rb
+++ b/src/ripper.rb
@@ -1,14 +1,7 @@
 #!/usr/bin/env ruby
 
-REQUIRED_VERSION = Gem::Version.new('2.5')
-if Gem::Version.new(RUBY_VERSION) < REQUIRED_VERSION
-  warn(
-    "Ruby version #{RUBY_VERSION} not supported. " \
-      "Please upgrade to #{REQUIRED_VERSION} or above."
-  )
-
-  exit 1
-end
+require_relative './utils'
+Prettier::PluginRuby::Utils.ensure_compatible_ruby_version!
 
 require 'json' unless defined?(JSON)
 require 'ripper'

--- a/src/utils.rb
+++ b/src/utils.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Prettier
+  module PluginRuby
+    module Utils
+      # We implement our own version checking here instead of using
+      # Gem::Version so that we can use the --disable-gems flag.
+      #
+      # @see https://github.com/prettier/plugin-ruby/pull/479#issue-380389558
+      def self.compatible_ruby_version?(current_version)
+        required_version = '2.5'
+        min_major, min_minor = required_version.split('.').map(&:to_i)
+        major, minor, _patch = current_version.split('.').map(&:to_i)
+
+        return true if major > min_major
+        return true if minor >= min_minor
+
+        false
+      end
+
+      def self.ensure_compatible_ruby_version!(current_version = RUBY_VERSION)
+        return if compatible_ruby_version?(current_version)
+
+        warn(
+          "Ruby version #{current_version} not s upported. " \
+            "Please upgrade to #{required_version} or above."
+        )
+
+        exit 1
+      end
+    end
+  end
+end

--- a/test/js/nodes.test.js
+++ b/test/js/nodes.test.js
@@ -37,6 +37,7 @@ const expectedUnhandledNodes = [
 
 const possibleNodes = () => {
   const child = spawnSync("ruby", [
+    "--disable-gems",
     "-rripper",
     "-e",
     "puts Ripper::PARSER_EVENTS"

--- a/test/js/setupTests.js
+++ b/test/js/setupTests.js
@@ -4,7 +4,7 @@ const prettier = require("prettier");
 const readline = require("readline");
 
 // Set RUBY_VERSION so certain tests only run for certain versions
-process.env.RUBY_VERSION = spawnSync("ruby", ["-e", "puts RUBY_VERSION"])
+process.env.RUBY_VERSION = spawnSync("ruby", ["--disable-gems", "-e", "puts RUBY_VERSION"])
   .stdout.toString()
   .trim();
 

--- a/test/rb/utils_test.rb
+++ b/test/rb/utils_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UtilsTest < Minitest::Test
+  def test_compatible_ruby_version
+    assert Prettier::PluginRuby::Utils.compatible_ruby_version?('2.5.0')
+  end
+
+  def test_incompatible_ruby_version
+    refute Prettier::PluginRuby::Utils.compatible_ruby_version?('2.4.0')
+  end
+end


### PR DESCRIPTION
Loading rubygems can be a slow operation. Worse yet, the load time
performance degrades as more gems are installed on the system. Luckily,
Ruby provides a flag to fix this: `--disable-gems`.

Using this flag significantly improves performance on my machine, here
are some results.

### Without --disable-gems

| file                                             | lint time |
|--------------------------------------------------|-----------|
| apps/admin/application.rb                        | 215ms     |
| apps/admin/config/routes.rb                      | 165ms     |
| apps/admin/controllers/about/show.rb             | 149ms     |
| apps/admin/controllers/accounts/index.rb         | 147ms     |
| apps/admin/controllers/authentication_helpers.rb | 151ms     |
| apps/admin/controllers/deployments/index.rb      | 148ms     |
| apps/admin/controllers/docs/index.rb             | 147ms     |
| apps/admin/controllers/docs/show.rb              | 144ms     |

### With --disable-gems

| file                                             | lint time |
|--------------------------------------------------|-----------|
| apps/admin/application.rb                        | 140ms     |
| apps/admin/config/routes.rb                      | 90ms      |
| apps/admin/controllers/about/show.rb             | 94ms      |
| apps/admin/controllers/accounts/index.rb         | 89ms      |
| apps/admin/controllers/authentication_helpers.rb | 92ms      |
| apps/admin/controllers/deployments/index.rb      | 87ms      |
| apps/admin/controllers/docs/index.rb             | 84ms      |
| apps/admin/controllers/docs/show.rb              | 88ms      |