### PR TITLE
add method_add_arg to calls noIndent

### DIFF
--- a/src/nodes/calls.js
+++ b/src/nodes/calls.js
@@ -2,7 +2,14 @@ const { concat, group, indent, softline } = require("../prettier");
 const toProc = require("../toProc");
 const { concatBody, first, makeCall } = require("../utils");
 
-const noIndent = ["array", "hash", "if", "method_add_block", "xstring_literal"];
+const noIndent = [
+  "array",
+  "hash",
+  "if",
+  "method_add_arg",
+  "method_add_block",
+  "xstring_literal"
+];
 
 module.exports = {
   call: (path, opts, print) => {


### PR DESCRIPTION
for code

```
Config::Download.new('rubocop-config-prettier', filename: 'rubocop.yml', url: 'https://raw.githubusercontent.com/xinminlabs/rubocop-config-prettier/master/config/rubocop.yml').perform
```

it was converted to

```
Config::Download.new(
  'rubocop-config-prettier',
  filename: 'rubocop.yml',
  url:
    'https://raw.githubusercontent.com/xinminlabs/rubocop-config-prettier/master/config/rubocop.yml'
)
  .perform
```

now, it is converted to

```
Config::Download.new(
  'rubocop-config-prettier',
  filename: 'rubocop.yml',
  url:
    'https://raw.githubusercontent.com/xinminlabs/rubocop-config-prettier/master/config/rubocop.yml'
).perform
```