### PR TITLE
add debug_print_doc command

### DIFF
--- a/bin/debug_print_doc
+++ b/bin/debug_print_doc
@@ -10,5 +10,8 @@ const code = fs.existsSync(process.argv[2])
       .join(" ")
       .replace(/\\n/g, "\n");
 
-const doc = prettier.__debug.printToDoc(code, { parser: "ruby", plugins: ["."] });
+const doc = prettier.__debug.printToDoc(code, {
+  parser: "ruby",
+  plugins: ["."]
+});
 console.log(prettier.__debug.formatDoc(doc));

--- a/bin/debug_print_doc
+++ b/bin/debug_print_doc
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const prettier = require("prettier");
+
+const code = fs.existsSync(process.argv[2])
+  ? fs.readFileSync(process.argv[2], "utf-8")
+  : process.argv
+      .slice(2)
+      .join(" ")
+      .replace(/\\n/g, "\n");
+
+const doc = prettier.__debug.printToDoc(code, { parser: "ruby", plugins: ["."] });
+console.log(prettier.__debug.formatDoc(doc));


### PR DESCRIPTION
the `debug_print_doc` command returns the debug print doc, like

```
[
  group([
    group(["Config", "::", "Download", indent([softline, ".", "new"])]),
    group([
      "(",
      indent([
        softline,
        "'",
        "rubocop-config-prettier",
        "'",
        ",",
        line,
        group([group(["filename:", indent([line, "'", "rubocop.yml", "'"])])])
      ]),
      softline,
      ")"
    ]),
    indent([softline, ".", "perform"])
  ]),
  hardline,
  breakParent
];
```

it helps to check internal behaviors.