### PR TITLE
wrap call name with group

### DIFF
--- a/src/nodes/calls.js
+++ b/src/nodes/calls.js
@@ -23,7 +23,7 @@ module.exports = {
     }
 
     return group(
-      concat([receiver, indent(concat([softline, operator, name]))])
+      concat([receiver, group(indent(concat([softline, operator, name])))])
     );
   },
   fcall: concatBody,


### PR DESCRIPTION
for code

```
Config::Download.new('rubocop-config-prettier', filename: 'rubocop.yml', url: 'https://raw.githubusercontent.com/xinminlabs/rubocop-config-prettier/master/config/rubocop.yml').perform
```

it was converted to

```
Config::Download.new(
  'rubocop-config-prettier',
  filename: 'rubocop.yml',
  url:
    'https://raw.githubusercontent.com/xinminlabs/rubocop-config-prettier/master/config/rubocop.yml'
)
  .perform
```

now, it is converted to

```
Config::Download.new(
  'rubocop-config-prettier',
  filename: 'rubocop.yml',
  url:
    'https://raw.githubusercontent.com/xinminlabs/rubocop-config-prettier/master/config/rubocop.yml'
).perform
```