### PR TITLE
`while` and `until` nodes with empty bodies

### DIFF
--- a/src/nodes/loops.js
+++ b/src/nodes/loops.js
@@ -10,6 +10,22 @@ const {
 const { containsAssignment } = require("../utils");
 
 const printLoop = (keyword, modifier) => (path, { inlineLoops }, print) => {
+  const [_predicate, statements] = path.getValue().body;
+
+  // If the only statement inside this while loop is a void statement, then we
+  // can shorten to just displaying the predicate and then a semicolon.
+  if (statements.body.length === 1 && statements.body[0].type === "void_stmt") {
+    return group(
+      concat([
+        keyword,
+        " ",
+        path.call(print, "body", 0),
+        ifBreak(softline, "; "),
+        "end"
+      ])
+    );
+  }
+
   let inlineParts = [
     path.call(print, "body", 1),
     ` ${keyword} `,

--- a/test/js/loops.test.js
+++ b/test/js/loops.test.js
@@ -61,6 +61,24 @@ describe.each(["while", "until"])("%s", keyword => {
       expect(
         `hash[:key] = ${keyword} false do break :value end`
       ).toChangeFormat(`hash[:key] = (break :value ${keyword} false)`));
+
+    test("empty body", () => {
+      const content = ruby(`
+        while foo
+        end
+      `);
+
+      return expect(content).toChangeFormat("while foo; end");
+    });
+
+    test("empty body, long predicate", () => {
+      const content = ruby(`
+        while ${long}
+        end
+      `);
+
+      return expect(content).toMatchFormat();
+    });
   });
 
   describe("inlines not allowed", () => {
@@ -87,6 +105,26 @@ describe.each(["while", "until"])("%s", keyword => {
         begin
           foo
         end ${keyword} bar
+      `);
+
+      return expect(content).toMatchFormat({ inlineLoops: false });
+    });
+
+    test("empty body", () => {
+      const content = ruby(`
+        while foo
+        end
+      `);
+
+      return expect(content).toChangeFormat("while foo; end", {
+        inlineLoops: false
+      });
+    });
+
+    test("empty body, long predicate", () => {
+      const content = ruby(`
+        while ${long}
+        end
       `);
 
       return expect(content).toMatchFormat({ inlineLoops: false });


### PR DESCRIPTION
Should print correctly. Fixes #454