### PR TITLE
fix dyna_symbol quote

### DIFF
--- a/src/ripper.rb
+++ b/src/ripper.rb
@@ -333,7 +333,7 @@ class RipperJS < Ripper
           opts = { char_start: char_start, char_end: char_pos }
           if event == :dyna_symbol
             index =
-              scanner_events.rindex do |scanner_event|
+              scanner_events.index do |scanner_event|
                 %i[@tstring_beg @tstring_end].include?(scanner_event[:type])
               end
 


### PR DESCRIPTION
I don't know why it uses `rindex` before, for code

```
where('lint_tool_configs.plugin': plugins + %w[core])
```

it will be transformed to

```
where(]lint_tool_configs.plugin]: plugins + %w[core])
```