### PR TITLE
optimize operators parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ end.to raise_error
 
 should maintain its `do...end` and not switch to inline braces otherwise the brace might get associated with the `1`.
 
+- [@flyerhzm] - Rewrite operators binary parser, as in:
+
+<!-- prettier-ignore -->
+```ruby
+[
+  '1111111111111111111111111111111111111111111111111111111111111111111111111',
+  222
+] +
+  [1]
+```
+
 ## [0.18.0] - 2020-03-17
 
 ### Added

--- a/src/nodes/operators.js
+++ b/src/nodes/operators.js
@@ -7,10 +7,18 @@ module.exports = {
 
     return group(
       concat([
-        concat([path.call(print, "body", 0), useNoSpace ? "" : " "]),
-        operator,
+        group(path.call(print, "body", 0)),
         indent(
-          concat([useNoSpace ? softline : line, path.call(print, "body", 2)])
+          concat([
+            useNoSpace ? "" : " ",
+            group(
+              concat([
+                operator,
+                useNoSpace ? softline : line,
+                path.call(print, "body", 2)
+              ])
+            )
+          ])
         )
       ])
     );


### PR DESCRIPTION
it converted code from

```
 ['1111111111111111111111111111111111111111111111111111111111111111111111111', 222] + [1]
```

to 

```
[
  '1111111111111111111111111111111111111111111111111111111111111111111111111',
  222
] +
  [1]
```

but it should be transformed to

```
[
  '1111111111111111111111111111111111111111111111111111111111111111111111111',
  222
] + [1]
```