### PR TITLE
add haml vscode language id

### DIFF
--- a/src/ruby.js
+++ b/src/ruby.js
@@ -78,7 +78,8 @@ module.exports = {
     {
       name: "HAML",
       parsers: ["haml"],
-      extensions: [".haml"]
+      extensions: [".haml"],
+      vscodeLanguageIds: ["haml"]
     }
   ],
   parsers: {

--- a/test/js/files.test.js
+++ b/test/js/files.test.js
@@ -7,4 +7,7 @@ describe("files", () => {
 
   test("handles extensions that match", () =>
     expect("files/test.rake").toInferRubyParser());
+
+  test("handles extensions that match haml", () =>
+    expect("files/test.haml").toInferHamlParser());
 });

--- a/test/js/setupTests.js
+++ b/test/js/setupTests.js
@@ -38,6 +38,20 @@ const realFormat = (content) =>
     plugins: ["."]
   });
 
+const toInferParser = (filename, parser) => {
+  const filepath = path.join(__dirname, filename);
+  const plugin = path.join(__dirname, "..", "..", "src", "ruby");
+  return prettier.getFileInfo(filepath, { plugins: [plugin] }).then((props) => {
+    return {
+      pass: props.inferredParser === parser,
+      message: () => `
+          Expected prettier to infer the ${parser} parser for ${filename},
+          but got ${props.inferredParser} instead
+        `
+    };
+  });
+};
+
 expect.extend({
   toChangeFormat(before, after, config = {}) {
     return checkFormat(before, after, config);
@@ -65,18 +79,10 @@ expect.extend({
     };
   },
   toInferRubyParser(filename) {
-    const filepath = path.join(__dirname, filename);
-    const plugin = path.join(__dirname, "..", "..", "src", "ruby");
-
-    return prettier
-      .getFileInfo(filepath, { plugins: [plugin] })
-      .then(({ inferredParser }) => ({
-        pass: inferredParser === "ruby",
-        message: () => `
-          Expected prettier to infer the ruby parser for ${filename},
-          but got ${inferredParser} instead
-        `
-      }));
+    return toInferParser(filename, "ruby");
+  },
+  toInferHamlParser(filename) {
+    return toInferParser(filename, "haml");
   }
 });
 


### PR DESCRIPTION
Enables haml formatting with VS Code Prettier