### PR TITLE
do not wrap line inside arg_paren for some cases

### DIFF
--- a/src/nodes/args.js
+++ b/src/nodes/args.js
@@ -11,6 +11,10 @@ const {
 const toProc = require("../toProc");
 const { makeArgs } = require("../utils");
 
+const shouldNotWrapLine = (args) =>
+  args.length === 0 ||
+  (args.length === 1 && typeof args[0] === "string" && args[0].length < 10);
+
 module.exports = {
   arg_paren: (path, opts, print) => {
     if (path.getValue().body[0] === null) {
@@ -34,19 +38,35 @@ module.exports = {
       return concat(["(", join(", ", args), ")"].concat(heredocs));
     }
 
-    const parenDoc = group(
-      concat([
-        "(",
-        indent(
-          concat([
-            softline,
-            join(concat([",", line]), args),
-            addTrailingCommas && !hasBlock ? ifBreak(",", "") : ""
-          ])
-        ),
-        concat([softline, ")"])
-      ])
-    );
+    let parenDoc;
+    if (shouldNotWrapLine(args)) {
+      parenDoc = group(
+        concat([
+          "(",
+          indent(
+            concat([
+              join(concat([",", line]), args),
+              addTrailingCommas && !hasBlock ? ifBreak(",", "") : ""
+            ])
+          ),
+          ")"
+        ])
+      );
+    } else {
+      parenDoc = group(
+        concat([
+          "(",
+          indent(
+            concat([
+              softline,
+              join(concat([",", line]), args),
+              addTrailingCommas && !hasBlock ? ifBreak(",", "") : ""
+            ])
+          ),
+          concat([softline, ")"])
+        ])
+      );
+    }
 
     if (heredocs.length === 1) {
       return group(concat([parenDoc].concat(heredocs)));

--- a/src/nodes/args.js
+++ b/src/nodes/args.js
@@ -11,7 +11,7 @@ const {
 const toProc = require("../toProc");
 const { docLength, makeArgs } = require("../utils");
 
-const MAX_NOT_WRAP_LINE_ARGS_LENGTH = 20;
+const MAX_NOT_WRAP_LINE_ARGS_LENGTH = 15;
 const shouldWrapLine = (args) =>
   args.reduce((sum, arg) => sum + docLength(arg), 0) >
     MAX_NOT_WRAP_LINE_ARGS_LENGTH ||

--- a/src/nodes/args.js
+++ b/src/nodes/args.js
@@ -9,11 +9,11 @@ const {
 } = require("../prettier");
 
 const toProc = require("../toProc");
-const { makeArgs } = require("../utils");
+const { docLength, makeArgs } = require("../utils");
 
+const MAX_NOT_WRAP_ARGS_LENGTH = 10;
 const shouldNotWrapLine = (args) =>
-  args.length === 0 ||
-  (args.length === 1 && typeof args[0] === "string" && args[0].length < 10);
+  args.reduce((sum, arg) => sum + docLength(arg), 0) < MAX_NOT_WRAP_ARGS_LENGTH;
 
 module.exports = {
   arg_paren: (path, opts, print) => {

--- a/src/nodes/args.js
+++ b/src/nodes/args.js
@@ -11,9 +11,10 @@ const {
 const toProc = require("../toProc");
 const { docLength, makeArgs } = require("../utils");
 
-const MAX_NOT_WRAP_ARGS_LENGTH = 10;
+const MAX_NOT_WRAP_ARGS_LENGTH = 20;
 const shouldNotWrapLine = (args) =>
-  args.reduce((sum, arg) => sum + docLength(arg), 0) < MAX_NOT_WRAP_ARGS_LENGTH;
+  (args.length == 1 && args[0].type !== 'group' && docLength(args[0]) < MAX_NOT_WRAP_ARGS_LENGTH) ||
+    args.reduce((sum, arg) => sum + docLength(arg), 0) < MAX_NOT_WRAP_ARGS_LENGTH;
 
 module.exports = {
   arg_paren: (path, opts, print) => {

--- a/test/js/blocks.test.js
+++ b/test/js/blocks.test.js
@@ -78,6 +78,20 @@ describe("blocks", () => {
     );
   });
 
+  // from ruby test/ruby/test_call.rb
+  test("inline do end", () =>
+    expect(`assert_nil(("a".sub! "b" do end&.foo {}))`).toChangeFormat(
+      ruby(`
+      assert_nil(
+        (
+          'a'.sub! 'b' do
+          end&.foo do
+          end
+        )
+      )
+    `)
+    ));
+
   test("excessed_comma nodes", () => expect("proc { |x,| }").toMatchFormat());
 
   describe("args", () => {

--- a/test/js/blocks.test.js
+++ b/test/js/blocks.test.js
@@ -78,20 +78,6 @@ describe("blocks", () => {
     );
   });
 
-  // from ruby test/ruby/test_call.rb
-  test("inline do end", () =>
-    expect(`assert_nil(("a".sub! "b" do end&.foo {}))`).toChangeFormat(
-      ruby(`
-      assert_nil(
-        (
-          'a'.sub! 'b' do
-          end&.foo do
-          end
-        )
-      )
-    `)
-    ));
-
   test("excessed_comma nodes", () => expect("proc { |x,| }").toMatchFormat());
 
   describe("args", () => {


### PR DESCRIPTION
It solves some cases when simple argument hit 80 chars like

```
thereisamethodcall(arg1, arg2).thereisanothermethodcall(arg1, arg2).asimpleone(arg)
```

was converted to

```
thereisamethodcall(arg1, arg2).thereisanothermethodcall(arg1, arg2).asimpleone(
  arg
)
```

but it would be better to be

```
thereisamethodcall(arg1, arg2).thereisanothermethodcall(arg1, arg2)
  .asimpleone(arg)
```

It will cause a special case, it won't transform code when there is only one long method with only one simple argument

```
hereisalonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglongmethod(arg)
```

but I rarely see developers write such code, the change worths it, what do you think?