### PR TITLE
comment handling for 'super' and 'zsuper'

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -28,5 +28,6 @@ module.exports = Object.assign(
   require("./nodes/scopes"),
   require("./nodes/statements"),
   require("./nodes/strings"),
+  require("./nodes/super"),
   require("./nodes/undef")
 );

--- a/src/nodes/methods.js
+++ b/src/nodes/methods.js
@@ -1,5 +1,5 @@
 const { concat, group, hardline, indent, join } = require("../prettier");
-const { first, literal } = require("../utils");
+const { first } = require("../utils");
 
 const printMethod = (offset) => (path, opts, print) => {
   const [_name, params, body] = path.getValue().body.slice(offset);
@@ -42,21 +42,4 @@ module.exports = {
   def: printMethod(0),
   defs: printMethod(2),
   methref: (path, opts, print) => join(".:", path.map(print, "body")),
-  super: (path, opts, print) => {
-    const args = path.getValue().body[0];
-
-    if (args.type === "arg_paren") {
-      // In case there are explicitly no arguments but they are using parens,
-      // we assume they are attempting to override the initializer and pass no
-      // arguments up.
-      if (args.body[0] === null) {
-        return "super()";
-      }
-
-      return concat(["super", path.call(print, "body", 0)]);
-    }
-
-    return concat(["super ", join(", ", path.call(print, "body", 0))]);
-  },
-  zsuper: literal("super")
-};
+}

--- a/src/nodes/super.js
+++ b/src/nodes/super.js
@@ -1,0 +1,23 @@
+const { concat, join } = require("../prettier");
+const { literal } = require("../utils");
+
+module.exports = {
+  super: (path, opts, print) => {
+    const args = path.getValue().body[0];
+
+    if (args.type === "arg_paren") {
+      // In case there are explicitly no arguments but they are using parens,
+      // we assume they are attempting to override the initializer and pass no
+      // arguments up.
+      if (args.body[0] === null) {
+        return "super()";
+      }
+
+      return concat(["super", path.call(print, "body", 0)]);
+    }
+
+    return concat(["super ", join(", ", path.call(print, "body", 0))]);
+  },
+  // version of super without any parens or args.
+  zsuper: literal("super")
+};

--- a/src/ripper.rb
+++ b/src/ripper.rb
@@ -226,8 +226,7 @@ class RipperJS < Ripper
         words_new: :@words_beg,
         xstring_literal: :@backtick,
         yield0: [:@kw, 'yield'],
-        yield: [:@kw, 'yield'],
-        zsuper: [:@kw, 'super']
+        yield: [:@kw, 'yield']
       }
 
       events.each do |event, (type, scanned)|
@@ -240,6 +239,16 @@ class RipperJS < Ripper
             char_end: char_pos
           )
         end
+      end
+
+      def on_zsuper(*body)
+        node = find_scanner_event(:@kw, "super")
+
+        super(*body).merge!(
+          start: node[:start],
+          char_start: node[:char_start],
+          char_end: node[:char_end]
+        )
       end
 
       # Array nodes can contain a myriad of subnodes because of the special

--- a/test/js/super.test.js
+++ b/test/js/super.test.js
@@ -11,4 +11,23 @@ describe("super", () => {
 
   test("multiple args, with parens", () =>
     expect("super(1, 2)").toMatchFormat());
+
+  describe("with comment", () => {
+    test("bare", () => expect("super # comment").toMatchFormat());
+
+    test("empty parens", () =>
+      expect("super() # comment").toMatchFormat());
+
+    test("one arg, no parens", () =>
+    expect("super 1 # comment").toMatchFormat());
+
+    test("one arg, with parens", () =>
+      expect("super(1) # comment").toMatchFormat());
+
+    test("multiple args, no parens", () =>
+      expect("super 1, 2 # comment").toMatchFormat());
+
+    test("multiple args, with parens", () =>
+      expect("super(1, 2) # comment").toMatchFormat());
+  })
 });


### PR DESCRIPTION
Summary:
This work ensures inline comments are attached after the 'super' and
'zsuper' nodes.
