### PR TITLE
Do not add an empty line after `rescue` when the block is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - [@alse] - Support `vscodeLanguageIds` for HAML.
 - [@ShayDavidson], [@kddeisz] - Don't allow replacing if/else with ternary if there's an assignment in the predicate.
 
+### Fixed
+
+- [@janklimo] - Do not add an empty line after `rescue` when the block is empty.
+
 ## [0.18.1] - 2020-04-05
 
 ### Changed
@@ -41,7 +45,7 @@ should maintain its `do...end` and not switch to inline braces otherwise the bra
 
 - [@ftes], [@kddeisz] - When old-form dynamic attributes are added to a `div` tag in HAML, it was previously skipping printing the `%div`, which led to it being incorrectly displayed.
 - [@ftes], [@kddeisz] - Previously if you had a long tag declaration with attributes that made it hit the line limit, then the content of the tag would be pushed to the next line but indented one character too many.
-- [@ftes], [@kddeisz] - Don't explicitly require JSON if it has already been loaed, as this can lead to rubygems activation errors.
+- [@ftes], [@kddeisz] - Don't explicitly require JSON if it has already been loaded, as this can lead to rubygems activation errors.
 - [@mmainz], [@kddeisz] - Handle heredocs as the receivers of call nodes, as in:
 
 <!-- prettier-ignore -->
@@ -866,6 +870,7 @@ would previously result in `array[]`, but now prints properly.
 [@ianks]: https://github.com/ianks
 [@jakeprime]: https://github.com/jakeprime
 [@jamescostian]: https://github.com/jamescostian
+[@janklimo]: https://github.com/janklimo
 [@joeyjoejoejr]: https://github.com/joeyjoejoejr
 [@johnschoeman]: https://github.com/johnschoeman
 [@joshuakgoldberg]: https://github.com/JoshuaKGoldberg

--- a/src/nodes/rescue.js
+++ b/src/nodes/rescue.js
@@ -53,7 +53,11 @@ module.exports = {
       parts.push(" StandardError");
     }
 
-    parts.push(indent(concat([hardline, path.call(print, "body", 2)])));
+    const rescueBody = path.call(print, "body", 2);
+
+    if (rescueBody.parts.length > 0) {
+      parts.push(indent(concat([hardline, rescueBody])));
+    }
 
     // This is the next clause on the `begin` statement, either another
     // `rescue`, and `ensure`, or an `else` clause.

--- a/test/js/rescue.test.js
+++ b/test/js/rescue.test.js
@@ -73,4 +73,15 @@ describe("rescue", () => {
     `)
     );
   });
+
+  test("empty rescue body", () => {
+    const content = ruby(`
+      begin
+        1
+      rescue NoMethodError
+      end
+    `);
+
+    return expect(content).toMatchFormat();
+  });
 });


### PR DESCRIPTION
@kddeisz I went ahead and updated the Changelog though I wasn't sure if that's expected of contributors or it's something you do yourself. Maybe we should update the Contribution guidelines with a section covering specific steps to take besides code updates when submitting a PR (e.g. updating changelog - changes, profile link, all contributors, etc).

Closes #549 