### PR TITLE
bug repro: method arguments deleted

### DIFF
--- a/test/js/comments.test.js
+++ b/test/js/comments.test.js
@@ -207,6 +207,17 @@ describe("comments", () => {
 
       return expect(content).toMatchFormat();
     });
+    test.skip("with trailing comma", () => {
+      const content = ruby(`
+        foo.bar(
+          bar: baz,
+          # this is a comment at the end of the method call
+        )
+      `);
+      // returns `foo.bar()`
+
+      return expect(content).toMatchFormat();
+    });
   });
 
   test.skip("causing ignored_nl", () => {


### PR DESCRIPTION
in case it's helpful, i added a skipped unit test to reproduce the incorrect code output reported in https://github.com/prettier/plugin-ruby/issues/571

this is my first time contributing, please let me know if there's a more helpful way to share bug reproductions like this!