### PR TITLE
Fix ternary -> if conditional with method call

### DIFF
--- a/test/js/method.test.js
+++ b/test/js/method.test.js
@@ -214,6 +214,11 @@ describe("method", () => {
             `foo(\n  ${long},\n  a${long}\n)`
           ));
 
+        test("with breaking ternary as first argument", () =>
+          expect(`foo bar ? ${long} : a${long}`).toChangeFormat(
+            `foo(\n  if bar\n    ${long}\n  else\n    a${long}\n  end\n)`
+          ));
+
         test("starting with trailing comma changes", () =>
           expect(`foo(${long}, a${long},)`).toChangeFormat(
             `foo(\n  ${long},\n  a${long}\n)`


### PR DESCRIPTION
Closes https://github.com/prettier/plugin-ruby/issues/590

Fixes an issue where ternary to `if/else` statement conversions can cause syntax errors if they were the first argument of a method call.

If we hit that case, this change adds parentheses to the method arguments, and indents arguments one level to match formatting of other method calls with parentheses.

For example,

```ruby
foo bar ? loooooooooooooooooooooooooooooong1 : loooooooooooooooooooooooooooong2
```
becomes
```ruby
foo(
  if bar
    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
  else
    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
  end
)
```
