### PR TITLE
Skip word-array transformations for other types of whitespace

### DIFF
--- a/src/nodes/arrays.js
+++ b/src/nodes/arrays.js
@@ -9,7 +9,7 @@ const {
   softline
 } = require("../prettier");
 
-const whitespaceLiterals = [" ", "\\t", "\\n", "\\r"];
+const preserveArraySubstrings = [" ", "\\"];
 
 const isStringArray = (args) =>
   args.body.every(
@@ -17,8 +17,8 @@ const isStringArray = (args) =>
       arg.type === "string_literal" &&
       arg.body[0].body.length === 1 &&
       arg.body[0].body[0].type === "@tstring_content" &&
-      !whitespaceLiterals.some((whitespace) =>
-        arg.body[0].body[0].body.includes(whitespace)
+      !preserveArraySubstrings.some((str) =>
+        arg.body[0].body[0].body.includes(str)
       )
   );
 

--- a/src/nodes/arrays.js
+++ b/src/nodes/arrays.js
@@ -9,13 +9,17 @@ const {
   softline
 } = require("../prettier");
 
+const whitespaceLiterals = [" ", "\\t", "\\n", "\\r"];
+
 const isStringArray = (args) =>
   args.body.every(
     (arg) =>
       arg.type === "string_literal" &&
       arg.body[0].body.length === 1 &&
       arg.body[0].body[0].type === "@tstring_content" &&
-      !arg.body[0].body[0].body.includes(" ")
+      !whitespaceLiterals.some((whitespace) =>
+        arg.body[0].body[0].body.includes(whitespace)
+      )
   );
 
 const isSymbolArray = (args) =>

--- a/test/js/array.test.js
+++ b/test/js/array.test.js
@@ -11,6 +11,15 @@ describe("array", () => {
   test("does not transform string arrays with spaces", () =>
     expect("['a', 'b c', 'd', 'e']").toMatchFormat());
 
+  test("does not transform string arrays with tabs", () =>
+    expect(`['a', "b\\tc", 'd', 'e']`).toMatchFormat());
+
+  test("does not transform string arrays with newlines", () =>
+    expect(`['a', "b\\nc", 'd', 'e']`).toMatchFormat());
+
+  test("does not transform string arrays with carriage returns", () =>
+    expect(`['a', "b\\rc", 'd', 'e']`).toMatchFormat());
+
   test("does not transform string arrays with interpolation", () =>
     expect(`['a', "b#{c}d", 'e']`).toMatchFormat());
 


### PR DESCRIPTION
Fixes a bug where non-space whitespace characters in arrays will be converted to word arrays without proper escaping. This prevents the conversion to word arrays for `\t`, `\n`, and `\r`, in addition to the existing check for spaces.

Previously, this:

```ruby
DELIMITERS = [";", "\t", "|", ","]
```

Converted to 
```ruby
DELIMITERS = %w[; \t | ,] 
# The second element is a string with two characters, not a string with a single tab character
# I.e. the array is changed to
# [";", "\\t", "|", ","]
```

But with this change, remains an explicit array with only quote conversion:
```ruby
DELIMITERS = [';', "\t", '|', ',']
```
