### PR TITLE
Add alignArguments option to configure argument alignment in statemen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Below are the options (from [`src/ruby.js`](src/ruby.js)) that `@prettier/plugin
 | `inlineLoops`        | `--inline-loops`         | `true`  | When it fits on one line, allows while and until statements to use the modifier form.                         |
 | `preferHashLabels`   | `--prefer-hash-labels`   | `true`  | When possible, uses the shortened hash key syntax, as opposed to hash rockets.                                |
 | `preferSingleQuotes` | `--prefer-single-quotes` | `true`  | When double quotes are not necessary for interpolation, prefers the use of single quotes for string literals. |
+| `alignArguments`     | `--align-arguments`      | `true`  | Align method call arguments when they're split over muliple lines.                                            |
 
 Any of these can be added to your existing [prettier configuration
 file](https://prettier.io/docs/en/configuration.html). For example:

--- a/src/nodes/commands.js
+++ b/src/nodes/commands.js
@@ -1,4 +1,12 @@
-const { align, concat, group, ifBreak, join, line } = require("../prettier");
+const {
+  align,
+  concat,
+  group,
+  ifBreak,
+  join,
+  line,
+  indent
+} = require("../prettier");
 const { docLength, makeArgs, makeCall } = require("../utils");
 
 const hasDef = (node) =>
@@ -32,10 +40,14 @@ module.exports = {
       return concat([command, " ", join(", ", args)].concat(heredocs));
     }
 
+    const { alignArguments } = opts;
+
     const joinedArgs = join(concat([",", line]), args);
     const breakArgs = hasDef(path.getValue())
       ? joinedArgs
-      : align(command.length + 1, joinedArgs);
+      : alignArguments
+      ? align(command.length + 1, joinedArgs)
+      : indent(joinedArgs);
 
     const commandDoc = group(
       ifBreak(
@@ -68,10 +80,14 @@ module.exports = {
       return concat(parts.concat([join(", ", args)]).concat(heredocs));
     }
 
+    const { alignArguments } = opts;
+
     const joinedArgs = join(concat([",", line]), args);
     const breakArgs = skipArgsAlign(path)
       ? joinedArgs
-      : align(docLength(concat(parts)), joinedArgs);
+      : alignArguments
+      ? align(docLength(concat(parts)), joinedArgs)
+      : indent(joinedArgs);
 
     const commandDoc = group(
       ifBreak(concat(parts.concat(breakArgs)), concat(parts.concat(joinedArgs)))

--- a/src/ruby.js
+++ b/src/ruby.js
@@ -115,6 +115,12 @@ module.exports = {
       description:
         "Adds a trailing comma to array literals, hash literals, and method calls."
     },
+    alignArguments: {
+      type: "boolean",
+      category: "Global",
+      default: true,
+      description: "Align method call arguments when split over lines"
+    },
     inlineConditionals: {
       type: "boolean",
       category: "Global",

--- a/test/js/method.test.js
+++ b/test/js/method.test.js
@@ -140,6 +140,24 @@ describe("method", () => {
         return expect(content).toMatchFormat();
       });
 
+      test("no alignment", () => {
+        const content = ruby(`
+          command.call some_method(
+                         ${long}
+                       )
+        `);
+
+        const expected = ruby(`
+          command.call some_method(
+              ${long}
+            )
+        `);
+
+        return expect(content).toChangeFormat(expected, {
+          alignArguments: false
+        });
+      });
+
       test("alignment for `to`", () => {
         const content = ruby(`
           expect(value).to matcher(
@@ -208,6 +226,31 @@ describe("method", () => {
     });
 
     describe("breaking", () => {
+      describe("without argument align", () => {
+        test("with block on the end", () =>
+          expect(`foo(${long}, &block)`).toChangeFormat(
+            `foo(\n  ${long},\n  &block\n)`
+          ));
+
+        test("on commands", () =>
+          expect(`command ${long}, a${long}`).toChangeFormat(
+            ruby(`
+            command ${long},
+              a${long}
+          `),
+            { alignArguments: false }
+          ));
+
+        test("on command calls", () =>
+          expect(`command.call ${long}, a${long}`).toChangeFormat(
+            ruby(`
+            command.call ${long},
+              a${long}
+          `),
+            { alignArguments: false }
+          ));
+      });
+
       describe("without trailing commas", () => {
         test("starting with no trailing comma stays", () =>
           expect(`foo(${long}, a${long})`).toChangeFormat(


### PR DESCRIPTION
…t calls

The default is:

```
object.some_method long_arg1,
                   long_arg2
```

Setting alignArguments to false will result in:

```
object.some_method long_arg1,
  long_arg2
```