### PR TITLE
Prevent ternary conversions with calls

### DIFF
--- a/src/nodes/conditionals.js
+++ b/src/nodes/conditionals.js
@@ -180,7 +180,7 @@ const canTernary = (path) => {
   const [predicate, stmts, addition] = path.getValue().body;
 
   return (
-    !["assign", "opassign"].includes(predicate.type) &&
+    !["assign", "opassign", "command_call"].includes(predicate.type) &&
     addition &&
     addition.type === "else" &&
     [stmts, addition.body[0]].every(canTernaryStmts)

--- a/src/nodes/conditionals.js
+++ b/src/nodes/conditionals.js
@@ -180,7 +180,9 @@ const canTernary = (path) => {
   const [predicate, stmts, addition] = path.getValue().body;
 
   return (
-    !["assign", "opassign", "command_call"].includes(predicate.type) &&
+    !["assign", "opassign", "command_call", "command"].includes(
+      predicate.type
+    ) &&
     addition &&
     addition.type === "else" &&
     [stmts, addition.body[0]].every(canTernaryStmts)

--- a/test/js/conditionals.test.js
+++ b/test/js/conditionals.test.js
@@ -328,6 +328,18 @@ describe("conditionals", () => {
         return expect(content).toMatchFormat();
       });
 
+      test("command call condition", () => {
+        const content = ruby(`
+          if a.foo? bar
+            1
+          else
+            2
+          end
+        `);
+
+        return expect(content).toMatchFormat();
+      });
+
       test("align long predicates", () =>
         expect(`${long} || ${long}a ? foo : bar`).toChangeFormat(
           ruby(`

--- a/test/js/conditionals.test.js
+++ b/test/js/conditionals.test.js
@@ -328,7 +328,19 @@ describe("conditionals", () => {
         return expect(content).toMatchFormat();
       });
 
-      test("command call condition", () => {
+      test("command with argument predicate", () => {
+        const content = ruby(`
+          if a b
+            1
+          else
+            2
+          end
+        `);
+
+        return expect(content).toMatchFormat();
+      });
+
+      test("command call with argument predicate", () => {
         const content = ruby(`
           if a.foo? bar
             1


### PR DESCRIPTION
Fixes a bug where method calls as conditions can change program behavior when converted to ternary shorthand.

For example, this
```ruby
if a.foo? bar
  1
else
  2
end
```

used to change to
```ruby
a.foo? bar ? 1 : 2 
# This evaluates as 
a.foo?(bar ? 1 : 2)
```

but now remains unchanged with this PR.



To be honest, I'd prefer to have the above example change to
```ruby
a.foo?(bar) ? 1 : 2 
```
But I couldn't figure out how to properly organize that without some crazy traversal in `conditionals.js`, which doesn't seem sustainable. Regardless, this PR now prevents AST changes that we ran into.