### PR TITLE
Ensure we're parsing ruby files using UTF-8 regardless of the system encoding.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,8 @@ jobs:
     - run: yarn install --frozen-lockfile
 
     # Actually run tests and lint
-    - run: |
+    - name: Lint and test
+      run: |
         yarn lint
         yarn print --check '**/*'
         yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - [@Rsullivan00] - Do not tranform word-literal arrays when there is an escape sequence.
 - [@steobrien], [@kddeisz] - Do not indent heredocs with calls more than they should be.
 - [@jpickwell] - Include .simplecov in filenames
+- [@github0013], [@kddeisz] - Ensure we're parsing ruby files using UTF-8 regardless of the system encoding.
 
 ## [0.19.0] - 2020-07-03
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,11 +1,27 @@
 const { spawnSync } = require("child_process");
 const path = require("path");
 
+// In order to properly parse ruby code, we need to tell the ruby process to
+// parse using UTF-8. Unfortunately, the way that you accomplish this looks
+// differently depending on your platform. This object below represents all of
+// the possible values of process.platform per:
+//   https://nodejs.org/api/process.html#process_process_platform
+const LANG = {
+  aix: "C.UTF-8",
+  darwin: "en_US.UTF-8",
+  freebsd: "C.UTF-8",
+  linux: "C.UTF-8",
+  openbsd: "C.UTF-8",
+  sunos: "C.UTF-8",
+  win32: ".UTF-8"
+}[process.platform];
+
 module.exports = (text, _parsers, _opts) => {
   const child = spawnSync(
     "ruby",
     ["--disable-gems", path.join(__dirname, "./ripper.rb")],
     {
+      env: { LANG },
       input: text,
       maxBuffer: 10 * 1024 * 1024 // 10MB
     }

--- a/test/js/lang.test.js
+++ b/test/js/lang.test.js
@@ -1,0 +1,27 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+expect.extend({
+  toHaveExitedCleanly(child) {
+    return {
+      pass: child.status === 0,
+      message: () => child.stderr.toString()
+    };
+  }
+});
+
+test("different lang settings don't break", () => {
+  const script = path.join(__dirname, "../../node_modules/.bin/prettier");
+  const child = spawnSync(
+    process.execPath,
+    [script, "--plugin", ".", "--parser", "ruby"],
+    {
+      env: {
+        LANG: "US-ASCII"
+      },
+      input: "'# あ'"
+    }
+  );
+
+  expect(child).toHaveExitedCleanly();
+});


### PR DESCRIPTION
Fixes #596