### PR TITLE
Don't overwrite ENV when spawning ruby process

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -21,7 +21,7 @@ module.exports = (text, _parsers, _opts) => {
     "ruby",
     ["--disable-gems", path.join(__dirname, "./ripper.rb")],
     {
-      env: { LANG },
+      env: Object.assign({}, process.env, { LANG }),
       input: text,
       maxBuffer: 10 * 1024 * 1024 // 10MB
     }


### PR DESCRIPTION
This should fix https://github.com/prettier/plugin-ruby/issues/621.

It seems passing `env` to `spawnSync` overwrites the whole ENV instead of adding the variables given. Although I'm not sure that is really what is happening, since it is working on my Mac when I run it locally. But this snippet fixes the problem when running inside a Docker container.