### PR TITLE
Don't convert between `lambda {}` and `-> {}`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 
 - [@kddeisz], [@ryan-hunter-pc] - Explicitly handle `break` and `next` keyword parentheses.
+- [@jbielick], [@kddeisz] - Don't convert between `lambda {}` and `-> {}`. Technically it's breaking the semantics of the program. Also because lambda method call arguments can't handle everything that stabby lambda can.
 
 ## [0.20.1] - 2020-09-04
 

--- a/playground/ripper.rb
+++ b/playground/ripper.rb
@@ -726,36 +726,6 @@ class RipperJS < Ripper
         super(ident, params, def_bodystmt)
       end
 
-      # By default, Ripper parses the expression `lambda { foo }` as a
-      # `method_add_block` node, so we can't turn it back into `-> { foo }`.
-      # This module overrides that behavior and reports it back as a `lambda`
-      # node instead.
-      def on_method_add_block(invocation, block)
-        # It's possible to hit a `method_add_block` node without going through
-        # `method_add_arg` node, ex: `super {}`. In that case we're definitely
-        # not going to transform into a lambda.
-        return super if invocation[:type] != :method_add_arg
-
-        fcall, args = invocation[:body]
-
-        # If there are arguments to the `lambda`, that means `lambda` has been
-        # overridden as a function so we cannot transform it into a `lambda`
-        # node.
-        if fcall[:type] != :fcall || args[:type] != :args || args[:body].any?
-          return super
-        end
-
-        ident = fcall.dig(:body, 0)
-        return super if ident[:type] != :@ident || ident[:body] != 'lambda'
-
-        super.tap do |sexp|
-          params, stmts = block[:body]
-          params ||= { type: :params, body: [] }
-
-          sexp.merge!(type: :lambda, body: [params, stmts])
-        end
-      end
-
       # We need to track for `mlhs_paren` and `massign` nodes whether or not
       # there was an extra comma at the end of the expression. For some reason
       # it's not showing up in the AST in an obvious way. In this case we're

--- a/src/nodes/lambdas.js
+++ b/src/nodes/lambdas.js
@@ -4,56 +4,86 @@ const {
   ifBreak,
   indent,
   line,
-  removeLines,
   softline
 } = require("../prettier");
-const { hasAncestor } = require("../utils");
+const { hasAncestor, nodeDive } = require("../utils");
+
+// We can have our params coming in as the first child of the main lambda node,
+// or if we have them wrapped in parens then they'll be one level deeper. Even
+// though it's possible to omit the parens if you only have one argument, we're
+// going to keep them in no matter what for consistency.
+const printLambdaParams = (path, print) => {
+  const steps = ["body", 0];
+  let params = nodeDive(path.getValue(), steps);
+
+  if (params.type !== "params") {
+    steps.push("body", 0);
+    params = nodeDive(path.getValue(), steps);
+  }
+
+  // If we don't have any params at all, then we're just going to bail out and
+  // print nothing. This is to avoid printing an empty set of parentheses.
+  if (params.body.every((type) => !type)) {
+    return "";
+  }
+
+  return group(
+    concat([
+      "(",
+      indent(concat([softline, path.call.apply(path, [print].concat(steps))])),
+      softline,
+      ")"
+    ])
+  );
+};
+
+// Lambda nodes represent stabby lambda literals, which can come in a couple of
+// flavors. They can use either braces or do...end for their block, and their
+// arguments can be not present, have no parentheses for a single argument, or
+// have parentheses for multiple arguments. Below are a couple of examples:
+//
+//     -> { 1 }
+//     -> a { a + 1 }
+//     ->(a) { a + 1 }
+//     ->(a, b) { a + b }
+//     ->(a, b = 1) { a + b }
+//
+//     -> do
+//       1
+//     end
+//
+//     -> a do
+//       a + 1
+//     end
+//
+//     ->(a, b) do
+//       a + b
+//     end
+//
+// Generally, we're going to favor do...end for the multi-line form and braces
+// for the single-line form. However, if we have an ancestor that is a command
+// or command_call node, then we'll need to use braces either way because of
+// operator precendence.
+const printLambda = (path, opts, print) => {
+  const params = printLambdaParams(path, print);
+  const inCommand = hasAncestor(path, ["command", "command_call"]);
+
+  return group(
+    ifBreak(
+      concat([
+        "->",
+        params,
+        " ",
+        inCommand ? "{" : "do",
+        indent(concat([line, path.call(print, "body", 1)])),
+        line,
+        inCommand ? "}" : "end"
+      ]),
+      concat(["->", params, " { ", path.call(print, "body", 1), " }"])
+    )
+  );
+};
 
 module.exports = {
-  lambda: (path, opts, print) => {
-    let params = path.getValue().body[0];
-    let paramsConcat = "";
-
-    if (params.type === "params") {
-      paramsConcat = path.call(print, "body", 0);
-    } else {
-      [params] = params.body;
-      paramsConcat = path.call(print, "body", 0, "body", 0);
-    }
-
-    const noParams = params.body.every((type) => !type);
-    const inlineLambda = concat([
-      "->",
-      noParams ? "" : concat(["(", paramsConcat, ")"]),
-      " { ",
-      path.call(print, "body", 1),
-      " }"
-    ]);
-
-    if (hasAncestor(path, ["command", "command_call"])) {
-      return group(
-        ifBreak(
-          concat([
-            "lambda {",
-            noParams ? "" : concat([" |", removeLines(paramsConcat), "|"]),
-            indent(concat([line, path.call(print, "body", 1)])),
-            concat([line, "}"])
-          ]),
-          inlineLambda
-        )
-      );
-    }
-
-    return group(
-      ifBreak(
-        concat([
-          "lambda do",
-          noParams ? "" : concat([" |", removeLines(paramsConcat), "|"]),
-          indent(concat([softline, path.call(print, "body", 1)])),
-          concat([softline, "end"])
-        ]),
-        inlineLambda
-      )
-    );
-  }
+  lambda: printLambda
 };

--- a/test/js/lambda.test.js
+++ b/test/js/lambda.test.js
@@ -13,11 +13,11 @@ describe("lambda", () => {
     expect("-> () { 1 }").toChangeFormat("-> { 1 }"));
 
   test("breaking stabby lambda literal", () =>
-    expect(`-> { ${long} }`).toChangeFormat(`lambda do\n  ${long}\nend`));
+    expect(`-> { ${long} }`).toChangeFormat(`-> do\n  ${long}\nend`));
 
   test("breaking stabby lambda literal with args", () => {
     const content = `->(a) { a + ${long} }`;
-    const expected = `lambda do |a|\n  a +\n    ${long}\nend`;
+    const expected = `->(a) do\n  a +\n    ${long}\nend`;
 
     return expect(content).toChangeFormat(expected);
   });
@@ -29,7 +29,7 @@ describe("lambda", () => {
     expect(`command :foo, -> { ${long} }`).toChangeFormat(
       ruby(`
       command :foo,
-              lambda {
+              -> {
                 ${long}
               }
     `)
@@ -42,7 +42,7 @@ describe("lambda", () => {
     expect(`command.call :foo, -> { ${long} }`).toChangeFormat(
       ruby(`
       command.call :foo,
-                   lambda {
+                   -> {
                      ${long}
                    }
     `)
@@ -52,7 +52,7 @@ describe("lambda", () => {
     expect(`command :foo, bar: -> { ${long} }`).toChangeFormat(
       ruby(`
       command :foo,
-              bar: lambda {
+              bar: -> {
                 ${long}
               }
     `)
@@ -64,7 +64,11 @@ describe("lambda", () => {
     return expect(content).toChangeFormat(
       ruby(`
       command :foo,
-              lambda { |${long}, a${long}, aa${long}|
+              ->(
+                ${long},
+                a${long},
+                aa${long}
+              ) {
                 true
               }
     `)
@@ -80,16 +84,4 @@ describe("lambda", () => {
 
   test("brackets with multiple args", () =>
     expect("a[1, 2, 3]").toMatchFormat());
-
-  describe("lambda method to stabby lambda literal", () => {
-    test("basic", () => expect("lambda { foo }").toChangeFormat("-> { foo }"));
-
-    test("with args", () =>
-      expect("lambda { |foo| foo }").toChangeFormat("->(foo) { foo }"));
-
-    test("does not transform overridden lambda", () =>
-      expect("lambda(foo) { foo }").toMatchFormat());
-
-    test("does not break on super", () => expect("super {}").toMatchFormat());
-  });
 });

--- a/test/rb/metadata_test.rb
+++ b/test/rb/metadata_test.rb
@@ -404,12 +404,6 @@ class MetadataTest < Minitest::Test
         foo + bar
       }
     SOURCE
-
-    assert_metadata :lambda, <<~SOURCE
-      lambda do |foo, bar|
-        foo + bar
-      end
-    SOURCE
   end
 
   def test_massign


### PR DESCRIPTION
Technically it's breaking the semantics of the program. Also because lambda method call arguments can't handle everything that stabby lambda can. Closes #651.