### PR TITLE
Trailing commas in hash arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - [@kddeisz], [@ryan-hunter-pc] - Explicitly handle `break` and `next` keyword parentheses.
 - [@jbielick], [@kddeisz] - Don't convert between `lambda {}` and `-> {}`. Technically it's breaking the semantics of the program. Also because lambda method call arguments can't handle everything that stabby lambda can.
 - [@kddeisz] - Turn off the `Symbol#to_proc` transform by default.
+- [@janklimo], [@kddeisz] - Properly handle trailing commas on hash arguments.
 
 ## [0.20.1] - 2020-09-04
 


### PR DESCRIPTION
Closes #545

Previously, printing this:

```ruby
patch '/api/v1/shops', params: { shop: { name: 'Single Lane', category: 'food_and_drinks' } }
```

would result in this:

```ruby
patch '/api/v1/shops',
      params: {
        shop: { name: 'Single Lane', category: 'food_and_drinks' }
      }
```

even if trailing commas was enabled. This is incorrect, as the third
line should have a trailing comma on it. The issue is that we were
attempting to handle trailing commas too low in the tree (from within
the assoclist_from_args node printing as opposed to the hash printing).