### PR TITLE
Better heredoc handling

### DIFF
--- a/src/nodes/arrays.js
+++ b/src/nodes/arrays.js
@@ -97,24 +97,15 @@ module.exports = {
     elements.forEach(({ element, elementPath }, index) => {
       const isInner = index !== elements.length - 1;
 
-      const isStraightHeredoc = element.type === "heredoc";
-      const isSquigglyHeredoc =
-        element.type === "string_literal" && element.body[0].type === "heredoc";
-
-      if (isStraightHeredoc || isSquigglyHeredoc) {
-        const heredocNode = isStraightHeredoc ? element : element.body[0];
-        const heredocPath = [print].concat(elementPath);
-
-        if (isSquigglyHeredoc) {
-          heredocPath.push("body", 0);
-        }
-
+      if (element.type === "heredoc") {
         normalDocs.push(
-          heredocNode.beging,
+          element.beging,
           isInner || addTrailingCommas ? "," : "",
           literalline,
-          concat(path.map.apply(path, heredocPath.concat("body"))),
-          heredocNode.ending,
+          concat(
+            path.map.apply(path, [print].concat(elementPath).concat("body"))
+          ),
+          element.ending,
           isInner ? line : ""
         );
       } else {

--- a/src/nodes/calls.js
+++ b/src/nodes/calls.js
@@ -4,20 +4,6 @@ const { concatBody, first, makeCall } = require("../utils");
 
 const noIndent = ["array", "hash", "if", "method_add_block", "xstring_literal"];
 
-const getHeredoc = (path, print, node) => {
-  if (node.type === "heredoc") {
-    const { beging, ending } = node;
-    return { beging, ending, content: ["body", 0, "body"] };
-  }
-
-  if (node.type === "string_literal" && node.body[0].type === "heredoc") {
-    const { beging, ending } = node.body[0];
-    return { beging, ending, content: ["body", 0, "body", 0, "body"] };
-  }
-
-  return null;
-};
-
 module.exports = {
   call: (path, opts, print) => {
     const [receiverNode, _operatorNode, messageNode] = path.getValue().body;
@@ -36,15 +22,14 @@ module.exports = {
     //     <<~TEXT.strip
     //       content
     //     TEXT
-    const heredoc = getHeredoc(path, print, receiverNode);
-    if (heredoc) {
+    if (receiverNode.type === "heredoc") {
       return concat([
-        heredoc.beging,
+        receiverNode.beging,
         printedOperator,
         printedMessage,
         literalline,
-        concat(path.map.apply(path, [print].concat(heredoc.content))),
-        heredoc.ending
+        concat(path.map(print, "body", 0, "body")),
+        receiverNode.ending
       ]);
     }
 

--- a/src/nodes/strings.js
+++ b/src/nodes/strings.js
@@ -133,12 +133,6 @@ module.exports = {
     const stringLiteral = path.getValue();
     const string = stringLiteral.body[0];
 
-    // If this string is actually a heredoc, bail out and return to the print
-    // function for heredocs
-    if (string.type === "heredoc") {
-      return path.call(print, "body", 0);
-    }
-
     // If the string is empty, it will not have any parts, so just print out the
     // quotes corresponding to the config
     if (string.body.length === 0) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,27 +66,16 @@ const makeArgs = (path, opts, print, argsIndex) => {
   const heredocs = [];
 
   argNodes.body.forEach((argNode, index) => {
-    let pattern;
-    let heredoc;
-
     if (argNode.type === "heredoc") {
-      pattern = [index, "body"];
-      heredoc = argNode;
-    } else if (
-      argNode.type === "string_literal" &&
-      argNode.body[0].type === "heredoc"
-    ) {
-      pattern = [index, "body", 0, "body"];
-      [heredoc] = argNode.body;
-    } else {
-      return;
+      const content = path.map.apply(
+        path,
+        argPattern.slice().concat([index, "body"])
+      );
+      heredocs.push(
+        concat([literalline].concat(content).concat([argNode.ending]))
+      );
+      args[index] = argNode.beging;
     }
-
-    const content = path.map.apply(path, argPattern.slice().concat(pattern));
-    heredocs.push(
-      concat([literalline].concat(content).concat([heredoc.ending]))
-    );
-    args[index] = heredoc.beging;
   });
 
   return { args, heredocs };


### PR DESCRIPTION
Previously there was kind of a weird dance where heredocs were either actual `heredoc` nodes (which represented squiggly heredocs) or they were `string_literal` nodes with an immediate child of `heredoc` (which represented straight-line heredocs). Now there's just one kind, which drastically simplifies what's going on.