### PR TITLE
Print method chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Changed
+
+- [@flyerhzm] - Print method chains by one indentation.
+
 ## [0.21.0] - 2020-12-02
 
 ### Changed

--- a/src/nodes/calls.js
+++ b/src/nodes/calls.js
@@ -1,51 +1,116 @@
-const { concat, group, indent, literalline, softline } = require("../prettier");
-const toProc = require("../toProc");
+const {
+  breakParent,
+  concat,
+  group,
+  indent,
+  literalline,
+  softline
+} = require("../prettier");
 const { concatBody, first, makeCall } = require("../utils");
+
+const toProc = require("../toProc");
 
 const noIndent = ["array", "hash", "if", "method_add_block", "xstring_literal"];
 
+// A call chain is when you call a bunch of methods right in a row. They're
+// pretty common on things like strings, arrays, or ActiveRecord::Relation
+// objects. This algorithm could be tweaked to include certain types of
+// arguments versus others, but this is a good first pass.
+function isCallChain(path) {
+  let parent = 0;
+  let parentNode = path.getParentNode(parent);
+  let callCount = 1;
+
+  while (parentNode) {
+    // We don't want to have special method handling if this method chain is
+    // actually an argument to something else
+    if (parentNode.type === "args") {
+      return false;
+    }
+
+    // We want to get a list of all of the ancestor call nodes, so that we can
+    // know if we need to provide special print handling for them.
+    if (parentNode.type === "call") {
+      callCount += 1;
+    }
+
+    parent += 1;
+    parentNode = path.getParentNode(parent);
+  }
+
+  // We consider it a call chain if there are >= 3 call nodes in a row.
+  return callCount >= 3;
+}
+
+function printCall(path, opts, print) {
+  const callNode = path.getValue();
+  const [receiverNode, _operatorNode, messageNode] = callNode.body;
+
+  const receiverDoc = path.call(print, "body", 0);
+  const operatorDoc = makeCall(path, opts, print);
+
+  // You can call lambdas with a special syntax that looks like func.(*args).
+  // In this case, "call" is returned for the 3rd child node.
+  const messageDoc =
+    messageNode === "call" ? messageNode : path.call(print, "body", 2);
+
+  // If we have a heredoc as a receiver, then we need to move the operator and
+  // the message up to start of the heredoc declaration, as in:
+  //
+  //     <<~TEXT.strip
+  //       content
+  //     TEXT
+  if (receiverNode.type === "heredoc") {
+    return concat([
+      receiverNode.beging,
+      operatorDoc,
+      messageDoc,
+      literalline,
+      concat(path.map(print, "body", 0, "body")),
+      receiverNode.ending
+    ]);
+  }
+
+  // For certain left sides of the call nodes, we want to attach directly to
+  // the } or end.
+  if (noIndent.includes(receiverNode.type)) {
+    return concat([receiverDoc, operatorDoc, messageDoc]);
+  }
+
+  // The right side of the call node, as in everything including the operator
+  // and beyond.
+  const rightSideDoc = indent(concat([softline, operatorDoc, messageDoc]));
+
+  // If this call is inside of a call chain (3 or more calls in a row), then
+  // we're going to provide special handling.
+  if (isCallChain(path)) {
+    // Recurse up the AST and mark all of the call nodes as being a part of a
+    // call chain so that when they get called to print they print themselves
+    // accordingly.
+    let parent = 0;
+    let parentNode = path.getParentNode();
+
+    while (parentNode) {
+      if (parentNode.type === "call") {
+        parentNode["callChain"] = true;
+      }
+      parent += 1;
+      parentNode = path.getParentNode(parent);
+    }
+
+    return group(concat([breakParent, receiverDoc, rightSideDoc]));
+  }
+
+  return group(
+    concat([
+      receiverDoc,
+      callNode["callChain"] ? rightSideDoc : group(rightSideDoc)
+    ])
+  );
+}
+
 module.exports = {
-  call: (path, opts, print) => {
-    const [receiverNode, _operatorNode, messageNode] = path.getValue().body;
-
-    const printedReceiver = path.call(print, "body", 0);
-    const printedOperator = makeCall(path, opts, print);
-
-    // You can call lambdas with a special syntax that looks like func.(*args).
-    // In this case, "call" is returned for the 3rd child node.
-    const printedMessage =
-      messageNode === "call" ? messageNode : path.call(print, "body", 2);
-
-    // If we have a heredoc as a receiver, then we need to move the operator and
-    // the message up to start of the heredoc declaration, as in:
-    //
-    //     <<~TEXT.strip
-    //       content
-    //     TEXT
-    if (receiverNode.type === "heredoc") {
-      return concat([
-        receiverNode.beging,
-        printedOperator,
-        printedMessage,
-        literalline,
-        concat(path.map(print, "body", 0, "body")),
-        receiverNode.ending
-      ]);
-    }
-
-    // For certain left sides of the call nodes, we want to attach directly to
-    // the } or end.
-    if (noIndent.includes(receiverNode.type)) {
-      return concat([printedReceiver, printedOperator, printedMessage]);
-    }
-
-    return group(
-      concat([
-        printedReceiver,
-        group(indent(concat([softline, printedOperator, printedMessage])))
-      ])
-    );
-  },
+  call: printCall,
   fcall: concatBody,
   method_add_arg: (path, opts, print) => {
     const [method, args] = path.map(print, "body");

--- a/test/js/calls.test.js
+++ b/test/js/calls.test.js
@@ -1,0 +1,25 @@
+const { ruby } = require("./utils");
+
+describe("calls", () => {
+  test("simple calls", () => {
+    const content = "posts.active.where('created_at > ?', 1.year.ago)";
+
+    return expect(content).toMatchFormat();
+  });
+
+  test("chain methods", () => {
+    const before = ruby(`
+      posts.active.where('created_at > ?', 1.year.ago).order('id asc').limit(10)
+    `);
+
+    const after = ruby(`
+      posts
+        .active
+        .where('created_at > ?', 1.year.ago)
+        .order('id asc')
+        .limit(10)
+    `);
+
+    return expect(before).toChangeFormat(after);
+  });
+});


### PR DESCRIPTION
Transforms

```ruby
posts.active.where('created_at > ?', 1.year.ago).order('id asc').limit(10)
```

to

```ruby
posts
  .active
  .where('created_at > ?', 1.year.ago)
  .order('id asc')
  .limit(10)
```

Closes #63. Supersedes #488. 

All credit to @flyerhzm here, this is just a rebased and slightly more performant version of his great work.