### PR TITLE
Maintain parse order during if/unless modifier expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - [@mmcnl], [@kddeisz] - Handle heredocs and blocks being passed to the same method.
 - [@johncsnyder], [@kddeisz] - Ensure correct formatting when breaking up conditionals with `inlineConditionals: false`.
 - [@Rsullivan00] - Ensure that when ternaries as command arguments get broken into multiple lines we add the necessary parentheses.
+- [@jbielick] - Maintain parse order during if/unless modifier expressions
 
 ## [0.21.0] - 2020-12-02
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,8 +12,9 @@ const concatBody = (path, opts, print) => concat(path.map(print, "body"));
 // If the node is a type of assignment or if the node is a paren and nested
 // inside that paren is a node that is a type of assignment.
 const containsAssignment = (node) =>
-  ["assign", "massign"].includes(node.type) ||
-  (node.type === "paren" && node.body[0].body.some(containsAssignment));
+  node &&
+  (["assign", "massign", "opassign"].includes(node.type) ||
+    (Array.isArray(node.body) && node.body.some(containsAssignment)));
 
 const docLength = (doc) => {
   if (doc.length) {

--- a/test/js/conditionals.test.js
+++ b/test/js/conditionals.test.js
@@ -23,6 +23,43 @@ describe("conditionals", () => {
     });
   });
 
+  describe("modifiers", () => {
+    describe.each(["if", "unless"])("%s keyword", (keyword) => {
+      test("when modifying an assignment expression", () => {
+        const content = `text = '${long}' ${keyword} text`;
+        const expected = ruby(`
+          text =
+            '${long}' ${keyword} text
+        `);
+
+        return expect(content).toChangeFormat(expected);
+      });
+
+      test("when modifying an abbreviated assignment expression", () => {
+        const content = `text ||= '${long}' ${keyword} text`;
+        const expected = ruby(`
+          text ||=
+            '${long}' ${keyword} text
+        `);
+
+        return expect(content).toChangeFormat(expected);
+      });
+
+      test("when modifying an expression with an assignment descendant", () => {
+        const content = `true && (text = '${long}') ${keyword} text`;
+        const expected = ruby(`
+          true &&
+            (
+              text =
+                '${long}'
+            ) ${keyword} text
+        `);
+
+        return expect(content).toChangeFormat(expected);
+      });
+    });
+  });
+
   describe("when inline allowed", () => {
     describe.each(["if", "unless"])("%s keyword", (keyword) => {
       test("inline stays", () => expect(`1 ${keyword} a`).toMatchFormat());
@@ -85,6 +122,18 @@ describe("conditionals", () => {
         const content = ruby(`
           array.each do |element|
             ${keyword} index = difference.index(element)
+              difference.delete_at(index)
+            end
+          end
+        `);
+
+        return expect(content).toMatchFormat();
+      });
+
+      test("breaks if the predicate is an op assignment", () => {
+        const content = ruby(`
+          array.each do |element|
+            ${keyword} index ||= difference.index(element)
               difference.delete_at(index)
             end
           end

--- a/test/js/parser.rb
+++ b/test/js/parser.rb
@@ -10,7 +10,9 @@ def gather
   return unless select([$stdin], nil, nil, 2)
 
   lines, line = [], nil
-  lines << line while (line = gets) != "---\n"
+  while (line = gets) != "---\n"
+    lines << line
+  end
   lines.join
 end
 


### PR DESCRIPTION
A rebased version of #654
Fixes #591