### PR TITLE
Ensure `not` keeps parentheses if they are being used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - [@Rsullivan00] - Ensure that when ternaries as command arguments get broken into multiple lines we add the necessary parentheses.
 - [@jbielick] - Maintain parse order during if/unless modifier expressions
 - [@flyerhzm] - Slight prettifying of wrapped args if doc length is under a certain value.
+- [@github0013], [@kddeisz] - Ensure `not` keeps parentheses if they are being used.
 
 ## [0.21.0] - 2020-12-02
 

--- a/src/nodes/operators.js
+++ b/src/nodes/operators.js
@@ -36,17 +36,24 @@ module.exports = {
       path.getValue().body[1] ? path.call(print, "body", 1) : ""
     ]),
   unary: (path, opts, print) => {
-    const oper = path.getValue().body[0];
-    const doc = path.call(print, "body", 1);
+    const node = path.getValue();
+    const oper = node.body[0];
+    const contentsDoc = path.call(print, "body", 1);
 
     if (oper === "not") {
-      // For the `not` operator, we're explicitly making the space character
-      // another element in the `concat` because there are some circumstances
-      // where we need to force parentheses (e.g., ternaries). In that case the
-      // printer for those nodes can just take out the space and put in parens.
-      return concat(["not", " ", doc]);
+      const parts = ["not"];
+
+      // Here we defer to the original source, as it's kind of difficult to
+      // determine if we can actually remove the parentheses being used.
+      if (node.paren) {
+        parts.push("(", contentsDoc, ")");
+      } else {
+        parts.push(" ", contentsDoc);
+      }
+
+      return concat(parts);
     }
 
-    return concat([oper[0], doc]);
+    return concat([oper[0], contentsDoc]);
   }
 };

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -314,7 +314,10 @@ class Prettier::Parser < Ripper
           end
 
         super(*body).merge!(
-          start: node[:start], char_start: node[:char_start], char_end: char_pos
+          start: node[:start],
+          char_start: node[:char_start],
+          char_end: char_pos,
+          paren: source[node[:char_end]...body[1][:char_start]].include?('(')
         )
       end
 

--- a/test/js/conditionals.test.js
+++ b/test/js/conditionals.test.js
@@ -189,6 +189,8 @@ describe("conditionals", () => {
           inlineConditionals: false
         }));
 
+      test("not operator parens", () => expect("not(true)").toMatchFormat());
+
       test("empty first body", () => {
         const content = ruby(`
           ${keyword} a


### PR DESCRIPTION
Closes #563 