### PR TITLE
Respect original call syntax

### DIFF
--- a/src/nodes/calls.js
+++ b/src/nodes/calls.js
@@ -21,9 +21,9 @@ function printCall(path, opts, print) {
   const operatorDoc = makeCall(path, opts, print);
 
   // You can call lambdas with a special syntax that looks like func.(*args).
-  // In this case, "call" is returned for the 3rd child node.
-  const messageDoc =
-    messageNode === "call" ? messageNode : path.call(print, "body", 2);
+  // In this case, "call" is returned for the 3rd child node. We don't alter
+  // call syntax so if `call` is implicit, we don't print it out.
+  const messageDoc = messageNode === "call" ? "" : path.call(print, "body", 2);
 
   // For certain left sides of the call nodes, we want to attach directly to
   // the } or end.

--- a/test/js/calls.test.js
+++ b/test/js/calls.test.js
@@ -31,4 +31,10 @@ describe("calls", () => {
 
     return expect(content).toMatchFormat();
   });
+
+  test("no explicit call doesn't add call", () =>
+    expect("a.(1, 2, 3)").toMatchFormat());
+
+  test("explicit call maintains call", () =>
+    expect("a.call(1, 2, 3)").toMatchFormat());
 });

--- a/test/js/lambda.test.js
+++ b/test/js/lambda.test.js
@@ -75,11 +75,6 @@ describe("lambda", () => {
     );
   });
 
-  test("no explicit call adds call", () =>
-    expect("a.(1, 2, 3)").toChangeFormat("a.call(1, 2, 3)"));
-
-  test("calls maintains call", () => expect("a.call(1, 2, 3)").toMatchFormat());
-
   test("empty brackets", () => expect("a[]").toMatchFormat());
 
   test("brackets with multiple args", () =>


### PR DESCRIPTION
@kddeisz let me know what you think. Moved the respective tests to `calls.test.js` to match the file which is responsible for this logic.

Closes #702 