### PR TITLE
Ensure `when` clauses with multiple predicates that can be split into…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - [@kddeisz] - Print hashes with consistent keys (e.g., if one key cannot be a hash label, use all hash rockets).
 - [@kddeisz] - Respect using `o` or not using `o` for octal numbers.
+- [@kddeisz] - Ensure `when` clauses with multiple predicates that can be split into multiple lines are split correctly.
 
 ## [1.0.0-rc1] - 2020-12-09
 

--- a/src/nodes/case.js
+++ b/src/nodes/case.js
@@ -28,13 +28,17 @@ module.exports = {
     // The `fill` builder command expects an array of docs alternating with
     // line breaks. This is so it can loop through and determine where to break.
     const preds = fill(
-      path
-        .call(print, "body", 0)
-        .reduce(
-          (accum, pred, index) =>
-            index === 0 ? [pred] : accum.concat([",", line, pred]),
-          null
-        )
+      path.call(print, "body", 0).reduce((accum, pred, index) => {
+        if (index === 0) {
+          return [pred];
+        }
+
+        // Pull off the last element and make it concat with a comma so that
+        // we can maintain alternating lines and docs.
+        return accum
+          .slice(0, -1)
+          .concat([concat([accum[accum.length - 1], ","]), line, pred]);
+      }, null)
     );
 
     const stmts = path.call(print, "body", 1);

--- a/test/js/case.test.js
+++ b/test/js/case.test.js
@@ -1,12 +1,38 @@
 const { long, ruby } = require("./utils");
 
 describe("case", () => {
-  test("empty case", () => expect("case\nwhen a\n  1\nend").toMatchFormat());
+  test("empty case", () => {
+    const content = ruby(`
+      case
+      when a
+        1
+      end
+    `);
 
-  test("single when", () => expect("case a\nwhen b\n  1\nend").toMatchFormat());
+    return expect(content).toMatchFormat();
+  });
 
-  test("multiple predicates, one when", () =>
-    expect("case a\nwhen b, c\n  1\nend").toMatchFormat());
+  test("single when", () => {
+    const content = ruby(`
+      case a
+      when b
+        1
+      end
+    `);
+
+    return expect(content).toMatchFormat();
+  });
+
+  test("multiple predicates, one when", () => {
+    const content = ruby(`
+      case a
+      when b, c
+        1
+      end
+    `);
+
+    return expect(content).toMatchFormat();
+  });
 
   test("breaking with multiple predicates, one when", () => {
     const content = ruby(`
@@ -21,12 +47,60 @@ describe("case", () => {
     return expect(content).toMatchFormat();
   });
 
-  test("multiple consecutive whens", () =>
-    expect("case a\nwhen b\nwhen c\n  1\nend").toMatchFormat());
+  test("breaking with multiple predicates, each one not too long", () => {
+    const content = ruby(`
+      case foo
+      when '${long.slice(0, 40)}', '${long.slice(0, 40)}'
+        bar
+      end
+    `);
 
-  test("basic multiple branches", () =>
-    expect("case a\nwhen b\n  1\nwhen c\n  2\nend").toMatchFormat());
+    const expected = ruby(`
+      case foo
+      when '${long.slice(0, 40)}',
+           '${long.slice(0, 40)}'
+        bar
+      end
+    `);
 
-  test("else clauses", () =>
-    expect("case a\nwhen b\n  1\nelse\n  2\nend").toMatchFormat());
+    return expect(content).toChangeFormat(expected);
+  });
+
+  test("multiple consecutive whens", () => {
+    const content = ruby(`
+      case a
+      when b
+      when c
+        1
+      end
+    `);
+
+    return expect(content).toMatchFormat();
+  });
+
+  test("basic multiple branches", () => {
+    const content = ruby(`
+      case a
+      when b
+        1
+      when c
+        2
+      end
+    `);
+
+    return expect(content).toMatchFormat();
+  });
+
+  test("else clauses", () => {
+    const content = ruby(`
+      case a
+      when b
+        1
+      else
+        2
+      end
+    `);
+
+    return expect(content).toMatchFormat();
+  });
 });


### PR DESCRIPTION
… multiple lines are split correctly