### PR TITLE
Do not change if regexp literal body has braces

### DIFF
--- a/src/parser.rb
+++ b/src/parser.rb
@@ -1719,7 +1719,9 @@ class Prettier::Parser < Ripper
   # expression literal, like /foo/. It can be followed by any number of
   # regexp_add events, which we'll append onto an array body.
   def on_regexp_new
-    find_scanner_event(:@regexp_beg).merge!(type: :regexp, body: [])
+    regexp_beg = find_scanner_event(:@regexp_beg)
+    beginning = regexp_beg[:body]
+    regexp_beg.merge!(type: :regexp, body: [], beginning: beginning)
   end
 
   # regexp_add is a parser event that represents a piece of a regular

--- a/test/js/nodes/regexp.test.js
+++ b/test/js/nodes/regexp.test.js
@@ -21,6 +21,14 @@ describe("regexp", () => {
 
   test("global interpolation", () => expect("/#$&/").toChangeFormat("/#{$&}/"));
 
+  test("do not change if { and / in regexp literal", () =>
+    expect("%r(a{b/c)").toMatchFormat());
+
+  test("do not change if } and / in regexp literal", () =>
+    expect("%r[a}b/c]").toMatchFormat());
+
+  test("parens with }", () => expect("%r(a}bc)").toChangeFormat("/a}bc/"));
+
   test("comments in regex", () => {
     const content = ruby(`
       /\\A

--- a/test/rb/metadata_test.rb
+++ b/test/rb/metadata_test.rb
@@ -556,6 +556,14 @@ class MetadataTest < Minitest::Test
   def test_regexp_literal
     assert_metadata :regexp_literal, '/foo/'
     assert_metadata :regexp_literal, '%r{foo}'
+    assert_metadata :regexp_literal, '%r(foo)'
+
+    assert_node_metadata(
+      :regexp_literal,
+      parse('%r(foo)'),
+      beginning: '%r(',
+      ending: ')'
+    )
   end
 
   def test_rescue


### PR DESCRIPTION
I found some edge cases when regexp literal body has braces.

`%r(a{b/c)` this regexp turns into `%r{a{b/c}` . which causes parser error. ( unterminated regexp meets end of file )

I tried to skip replacing if literal body has braces. 

--

another solution: Escape braces? ( `%r{a\{b/c}` )  but It was complicated for me.