### PR TITLE
Long method chains with args at the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - [@rindek], [@kddeisz] - Do not remove parentheses when using the special `call` syntax with no arguments.
 - [@ykpythemind] - Do not change regexp bounds if the body has certain content.
 - [@karanmandal], [@kddeisz] - Correctly print for loops.
+- [@rafbm], [@kddeisz] - If there are method chains with arguments only at the end, we should group the method chain and the method args.
 
 ## [1.0.1] - 2020-12-12
 
@@ -1071,6 +1072,7 @@ would previously result in `array[]`, but now prints properly.
 [@overload119]: https://github.com/Overload119
 [@petevk]: https://github.com/petevk
 [@pje]: https://github.com/pje
+[@rafbm]: https://github.com/rafbm
 [@rindek]: https://github.com/rindek
 [@rosskinsella]: https://github.com/RossKinsella
 [@rsullivan00]: https://github.com/Rsullivan00

--- a/test/js/nodes/calls.test.js
+++ b/test/js/nodes/calls.test.js
@@ -1,4 +1,4 @@
-const { ruby } = require("../utils");
+const { long, ruby } = require("../utils");
 
 describe("calls", () => {
   test("simple calls", () => {
@@ -24,6 +24,17 @@ describe("calls", () => {
     `);
 
     return expect(before).toChangeFormat(after);
+  });
+
+  test("chains of methods with one with arguments right at the top", () => {
+    const content = ruby(`
+      aaa.bbb.ccc.ddd.eee.merge(
+        ${long.slice(0, 30)}: 'aaa',
+        ${long.slice(0, 31)}: 'bbb'
+      )
+    `);
+
+    return expect(content).toMatchFormat();
   });
 
   test("tons of calls that fit on one line", () => {


### PR DESCRIPTION
If you have something like

```ruby
config.action_dispatch.rescue_responses.merge!(
  # We created more threads than RAILS_MAX_THREADS
  'ActiveRecord::ConnectionTimeoutError' => :service_unavailable,
  # Some query hits a timeout
  'ActiveRecord::QueryCanceled' => :service_unavailable,
  # Rack::Timeout
  'Rack::Timeout::RequestExpiryError' => :service_unavailable,
  'Rack::Timeout::RequestTimeoutError' => :service_unavailable,
  'Rack::Timeout::RequestTimeoutException' => :service_unavailable,
)
```

then we want to group the args and the method chain.

Closes #729 