### PR TITLE
Rename literalLineNoBreak to literallineWithoutBreakParent

### DIFF
--- a/src/ruby/embed.js
+++ b/src/ruby/embed.js
@@ -8,7 +8,7 @@ const {
   stripTrailingHardline
 } = require("../prettier");
 
-const { literalLineNoBreak } = require("../utils");
+const { literallineWithoutBreakParent } = require("../utils");
 
 const parsers = {
   css: "css",
@@ -30,7 +30,7 @@ function replaceNewlines(doc) {
       ? concat(
           currentDoc
             .split(/(\n)/g)
-            .map((v, i) => (i % 2 === 0 ? v : literalLineNoBreak))
+            .map((v, i) => (i % 2 === 0 ? v : literallineWithoutBreakParent))
         )
       : currentDoc
   );
@@ -106,7 +106,7 @@ function embed(path, print, textToDoc, _opts) {
 
   // Pass that content into the embedded parser. Get back the doc node.
   const formatted = concat([
-    literalLineNoBreak,
+    literallineWithoutBreakParent,
     replaceNewlines(stripTrailingHardline(textToDoc(content, { parser })))
   ]);
 
@@ -119,7 +119,7 @@ function embed(path, print, textToDoc, _opts) {
         group(
           concat([
             indent(markAsRoot(formatted)),
-            literalLineNoBreak,
+            literallineWithoutBreakParent,
             ending.trim()
           ])
         )
@@ -132,7 +132,9 @@ function embed(path, print, textToDoc, _opts) {
   return markAsRoot(
     concat([
       path.call(print, "beging"),
-      lineSuffix(group(concat([formatted, literalLineNoBreak, ending.trim()])))
+      lineSuffix(
+        group(concat([formatted, literallineWithoutBreakParent, ending.trim()]))
+      )
     ])
   );
 }

--- a/src/ruby/nodes/heredocs.js
+++ b/src/ruby/nodes/heredocs.js
@@ -1,5 +1,5 @@
 const { concat, group, lineSuffix, join } = require("../../prettier");
-const { literalLineNoBreak } = require("../../utils");
+const { literallineWithoutBreakParent } = require("../../utils");
 
 function printHeredoc(path, opts, print) {
   const { body, ending } = path.getValue();
@@ -11,7 +11,7 @@ function printHeredoc(path, opts, print) {
     }
 
     // In this case, the part of the string is just regular string content
-    return join(literalLineNoBreak, part.body.split("\n"));
+    return join(literallineWithoutBreakParent, part.body.split("\n"));
   });
 
   // We use a literalline break because matching indentation is required
@@ -23,7 +23,9 @@ function printHeredoc(path, opts, print) {
     concat([
       path.call(print, "beging"),
       lineSuffix(
-        group(concat([literalLineNoBreak].concat(parts).concat(ending)))
+        group(
+          concat([literallineWithoutBreakParent].concat(parts).concat(ending))
+        )
       )
     ])
   );

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ module.exports = {
   isEmptyStmts: require("./utils/isEmptyStmts"),
   hasAncestor: require("./utils/hasAncestor"),
   literal: require("./utils/literal"),
-  literalLineNoBreak: require("./utils/literalLineNoBreak"),
+  literallineWithoutBreakParent: require("./utils/literallineWithoutBreakParent"),
   makeCall: require("./utils/makeCall"),
   noIndent: require("./utils/noIndent"),
   printEmptyCollection: require("./utils/printEmptyCollection"),

--- a/src/utils/literalLineNoBreak.js
+++ b/src/utils/literalLineNoBreak.js
@@ -1,7 +1,0 @@
-const literalLineNoBreak = {
-  type: "line",
-  hard: true,
-  literal: true
-};
-
-module.exports = literalLineNoBreak;

--- a/src/utils/literallineWithoutBreakParent.js
+++ b/src/utils/literallineWithoutBreakParent.js
@@ -1,0 +1,7 @@
+const literallineWithoutBreakParent = {
+  type: "line",
+  hard: true,
+  literal: true
+};
+
+module.exports = literallineWithoutBreakParent;


### PR DESCRIPTION
[`hardlineWithoutBreakParent` and `literallineWithoutBreakParent`](https://github.com/prettier/prettier/blob/main/commands.md#hardlinewithoutbreakparent-and-literallinewithoutbreakparent) have been added to `prettier.doc.builders` and will be available in the next release. For consistency, this PR renames `literalLineNoBreak` in this project to `literallineWithoutBreakParent`.