### PR TITLE
Document RuboCop's Style/Lambda should be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 
 - [#812](https://github.com/prettier/plugin-ruby/issues/812) - valscion, kddeisz - Splats and blocks within args that have comments attached should place their respective operators in the right place.
+- [#816](https://github.com/prettier/plugin-ruby/pull/816) - valscion - Document RuboCop's Style/Lambda should be disabled
 
 ## [1.5.2] - 2021-02-03
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -24,3 +24,6 @@ Style/TrailingCommaInArrayLiteral: # trailingComma
 
 Style/TrailingCommaInHashLiteral: # trailingComma
   Enabled: false
+
+Style/Lambda:
+  Enabled: false


### PR DESCRIPTION
I noticed that [`Style/Lambda` cop from RuboCop](https://docs.rubocop.org/rubocop/1.8/cops_style.html#stylelambda) has a chance on conflicting with the way `@prettier/plugin-ruby` wants to format code.

Say we have this original code:

```rb
something = -> { a_very_long_line_that_needs_to_be_splitted_to_next_one_aaa_bbb }
```

After prettifying, the code will turn to this:

```rb
something = -> do
  a_very_long_line_that_needs_to_be_splitted_to_next_one_aaa_bbb
end
```

However, RuboCop does not like this, and would prefer multiline lambdas to instead look like this:

```rb
something = lambda do
  a_very_long_line_that_needs_to_be_splitted_to_next_one_aaa_bbb
end
```

But if I did that change, then after prettier run, the code would turn to this one:

```rb
something =
  lambda { a_very_long_line_that_needs_to_be_splitted_to_next_one_aaa_bbb }
```

which `Style/Lambda` cop would then complain that the code should be like this instead:

```rb
something =
  -> { a_very_long_line_that_needs_to_be_splitted_to_next_one_aaa_bbb }
```

...but if I did that, then we'd be back at this code after prettier run:

```rb
something = -> do
  a_very_long_line_that_needs_to_be_splitted_to_next_one_aaa_bbb
end
```

---

So in the end, what we decided to do was disable `Style/Lambda` for the Ruby files that are formatted with Prettier. I figured it would be worth it to document this cop needs to be disabled in order not to cause conflicts between RuboCop and `@prettier/plugin-ruby`.