### PR TITLE
Fix for #814

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - [#812](https://github.com/prettier/plugin-ruby/issues/812) - valscion, kddeisz - Splats and blocks within args that have comments attached should place their respective operators in the right place.
 - [#816](https://github.com/prettier/plugin-ruby/pull/816) - valscion - Document RuboCop's Style/Lambda should be disabled
+- [#814](https://github.com/prettier/plugin-ruby/issues/814) - jscheid, kddeisz - Provide better errors when the source location of the error is known.
 
 ## [1.5.2] - 2021-02-03
 

--- a/src/haml/parser.rb
+++ b/src/haml/parser.rb
@@ -131,8 +131,6 @@ module Prettier
   class HAMLParser
     def self.parse(source)
       Haml::Parser.new({}).call(source).as_json
-    rescue StandardError
-      false
     end
   end
 end

--- a/src/parser/server.rb
+++ b/src/parser/server.rb
@@ -48,6 +48,11 @@ loop do
     else
       socket.write('{ "error": true }')
     end
+  rescue Prettier::Parser::ParserError => error
+    loc = { start: { line: error.lineno, column: error.column } }
+    socket.write(JSON.fast_generate(error: error.message, loc: loc))
+  rescue StandardError => error
+    socket.write(JSON.fast_generate(error: error.message))
   ensure
     socket.close
   end

--- a/src/rbs/parser.rb
+++ b/src/rbs/parser.rb
@@ -87,8 +87,6 @@ module Prettier
   class RBSParser
     def self.parse(text)
       { declarations: RBS::Parser.parse_signature(text) }
-    rescue StandardError
-      false
     end
   end
 end

--- a/src/ruby/parser.rb
+++ b/src/ruby/parser.rb
@@ -1729,6 +1729,28 @@ class Prettier::Parser < Ripper
     )
   end
 
+  # A special parser error so that we can get nice syntax displays on the error
+  # message when prettier prints out the results.
+  class ParserError < StandardError
+    attr_reader :lineno, :column
+
+    def initialize(error, lineno, column)
+      super(error)
+      @lineno = lineno
+      @column = column
+    end
+  end
+
+  # If we encounter a parse error, just immediately bail out so that our runner
+  # can catch it.
+  def on_parse_error(error, *)
+    raise ParserError.new(error, lineno, column)
+  end
+  alias on_alias_error on_parse_error
+  alias on_assign_error on_parse_error
+  alias on_class_name_error on_parse_error
+  alias on_param_error on_parse_error
+
   # The program node is the very top of the AST. Here we'll attach all of
   # the comments that we've gathered up over the course of parsing the
   # source string. We'll also attach on the __END__ content if there was

--- a/test/js/files.test.js
+++ b/test/js/files.test.js
@@ -1,10 +1,20 @@
+const path = require("path");
+const { getFileInfo } = require("prettier");
+
+const plugin = require("../../src/plugin");
+
+function getInferredParser(filename) {
+  const filepath = path.join(__dirname, filename);
+
+  return getFileInfo(filepath, { plugins: [plugin] }).then(
+    ({ inferredParser }) => inferredParser
+  );
+}
+
 describe("files", () => {
-  test("handles full files that match", () =>
-    expect("files/Gemfile").toInferParser());
+  const cases = ["files/Gemfile", "files/shebang", "files/test.rake"];
 
-  test("handles shebangs that match", () =>
-    expect("files/shebang").toInferParser());
-
-  test("handles extensions that match", () =>
-    expect("files/test.rake").toInferParser());
+  test.each(cases)("infers Ruby parser from %s", (filename) =>
+    expect(getInferredParser(filename)).resolves.toBe("ruby")
+  );
 });

--- a/test/js/ruby/errors.test.js
+++ b/test/js/ruby/errors.test.js
@@ -1,7 +1,25 @@
+const prettier = require("prettier");
 const { print } = require("../../../src/ruby/printer");
 
 describe("errors", () => {
-  test("invalid ruby", () => expect("<>").toFailFormat());
+  const cases = [
+    "alias $a $1",
+    "self = 1",
+    "$` = 1",
+    "class foo; end",
+    "def foo(A) end",
+    "def foo($a) end",
+    "def foo(@a) end",
+    "def foo(@@a) end",
+    "<>"
+  ];
+
+  test.each(cases)("fails for %s", (content) => {
+    const format = () =>
+      prettier.format(content, { parser: "ruby", plugins: ["."] });
+
+    expect(format).toThrow();
+  });
 
   test("when encountering an unsupported node type", () => {
     const path = { getValue: () => ({ type: "unsupported", body: {} }) };

--- a/test/js/setupTests.js
+++ b/test/js/setupTests.js
@@ -1,5 +1,4 @@
 const net = require("net");
-const path = require("path");
 const prettier = require("prettier");
 
 // eslint-disable-next-line no-underscore-dangle
@@ -76,36 +75,5 @@ expect.extend({
   },
   toMatchFormat(before, config = {}) {
     return checkFormat(before, before.code || before, config);
-  },
-  toFailFormat(before, message) {
-    let pass = false;
-    let error = null;
-
-    try {
-      prettier.format(before, { parser: "ruby", plugins: ["."] });
-    } catch (caught) {
-      error = caught;
-      pass = caught.message === message;
-    }
-
-    return {
-      pass,
-      message: () => `
-        Expected format to throw an error for ${before} with ${message},
-        but got ${error.message} instead
-      `
-    };
-  },
-  toInferParser(filename) {
-    const filepath = path.join(__dirname, filename);
-    const plugin = path.join(__dirname, "..", "..", "src", "plugin");
-
-    return prettier
-      .getFileInfo(filepath, { plugins: [plugin] })
-      .then((props) => ({
-        pass: props.inferredParser === "ruby",
-        message: () =>
-          `Expected prettier to infer the ruby parser for ${filename}, but got ${props.inferredParser} instead`
-      }));
   }
 });


### PR DESCRIPTION
Fixes #814.

Before:

```
$ bin/print foo.rb
#<Thread:0x00007f804a87a240 /Users/kddeisz/Documents/projects/prettier/plugin-ruby/src/parser/server.rb:33 run> terminated with exception (report_on_exception is true):
/Users/kddeisz/Documents/projects/prettier/plugin-ruby/src/ruby/parser.rb:2037:in `on_stmts_add': undefined method `<<' for {:type=>:method_add_arg, :body=>[{:type=>:fcall, :body=>[{:type=>:@ident, :body=>"foo", :sl=>4, :el=>4, :sc=>22, :ec=>25}], :sl=>4, :el=>4, :sc=>22, :ec=>25}, {:type=>:arg_paren, :body=>[nil], :sl=>4, :sc=>25, :el=>4, :ec=>27}], :sl=>4, :sc=>22, :el=>4, :ec=>27}:Hash (NoMethodError)
Did you mean?  <
	from /Users/kddeisz/Documents/projects/prettier/plugin-ruby/src/ruby/parser.rb:98:in `parse'
	from /Users/kddeisz/Documents/projects/prettier/plugin-ruby/src/ruby/parser.rb:98:in `parse'
	from /Users/kddeisz/Documents/projects/prettier/plugin-ruby/src/parser/server.rb:39:in `block (2 levels) in <main>'
Could not parse response from server
{ command: 'nc', stdout: '', stderr: '', status: 0 }

/Users/kddeisz/Documents/projects/prettier/plugin-ruby/node_modules/prettier/index.js:13645
    throw error.stack;
    ^
Error: An unknown error occurred
    at parseSync (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/src/parser/parseSync.js:17:11)
    at Object.parse (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/src/ruby/parser.js:8:10)
    at Object.parse (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/node_modules/prettier/index.js:13625:19)
    at coreFormat (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/node_modules/prettier/index.js:14899:14)
    at format (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/node_modules/prettier/index.js:15131:14)
    at Object.formatWithCursor (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/node_modules/prettier/index.js:57542:12)
    at Object.<anonymous> (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/bin/print:25:32)
    at Module._compile (internal/modules/cjs/loader.js:1075:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1096:10)
    at Module.load (internal/modules/cjs/loader.js:940:32)
(Use `node --trace-uncaught ...` to show where the exception was thrown)
```

After:

```
$ bin/print foo.rb
/Users/kddeisz/Documents/projects/prettier/plugin-ruby/node_modules/prettier/index.js:13640
      throw error;
      ^

Error: syntax error, unexpected local variable or method, expecting ')'
  2 |   <<~HERE
  3 |   HERE
> 4 | foo()
  5 | foo()
  6 | 
    at parseSync (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/src/parser/parseSync.js:17:19)
    at Object.parse (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/src/ruby/parser.js:8:10)
    at Object.parse (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/node_modules/prettier/index.js:13625:19)
    at coreFormat (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/node_modules/prettier/index.js:14899:14)
    at format (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/node_modules/prettier/index.js:15131:14)
    at Object.formatWithCursor (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/node_modules/prettier/index.js:57542:12)
    at Object.<anonymous> (/Users/kddeisz/Documents/projects/prettier/plugin-ruby/bin/print:25:32)
    at Module._compile (internal/modules/cjs/loader.js:1075:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1096:10)
    at Module.load (internal/modules/cjs/loader.js:940:32) {
  loc: { start: { line: 4, column: 0 } },
  codeFrame: '\x1B[0m \x1B[90m 2 | \x1B[39m  \x1B[33m<<\x1B[39m\x1B[33m~\x1B[39m\x1B[33mHERE\x1B[39m\x1B[0m\n' +
    '\x1B[0m \x1B[90m 3 | \x1B[39m  \x1B[33mHERE\x1B[39m\x1B[0m\n' +
    '\x1B[0m\x1B[31m\x1B[1m>\x1B[22m\x1B[39m\x1B[90m 4 | \x1B[39mfoo()\x1B[0m\n' +
    '\x1B[0m \x1B[90m 5 | \x1B[39mfoo()\x1B[0m\n' +
    '\x1B[0m \x1B[90m 6 | \x1B[39m\x1B[0m'
}
```