### PR TITLE
Incompatible Rubocop rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Changed
+
+- [#834](https://github.com/prettier/plugin-ruby/pull/834) - ayrton - Ignore Rubocop's incompatible Style/GuardClause and Style/IfUnlessModifier rules.
+
 ## [1.5.3] - 2021-02-28
 
 ### Changed

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -27,7 +27,7 @@ Style/TrailingCommaInHashLiteral: # trailingComma
 
 Style/Lambda:
   Enabled: false
-  
+
 Style/GuardClause:
   Enabled: false
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -27,3 +27,9 @@ Style/TrailingCommaInHashLiteral: # trailingComma
 
 Style/Lambda:
   Enabled: false
+  
+Style/GuardClause:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false


### PR DESCRIPTION
Noticed these rules are incompatible with prettier:

- "Use a guard clause instead of wrapping the code inside a conditional expression."
- "Favor modifier if usage when having a single-line body."