### PR TITLE
README: Update rubocop instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ inherit_gem:
 #### `npm` package
 
 ```yaml
-inherit_gem:
+inherit_from:
   - node_modules/@prettier/plugin-ruby/rubocop.yml
 ```
 


### PR DESCRIPTION
- `inherit_gem` does not work with a path, errors out in Rubocop because
of the format, it needs a key and value.
- With `inherit_from` it works.
