### PR TITLE
Add VSCode setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,12 +184,12 @@ inherit_from:
 
 - Add the npm `@prettier/plugin-ruby` package to your project as described above.
 - Install the [Prettier - Code Formatter](https://github.com/prettier/prettier-vscode) extension.
-- Configure in your `settings.json`:
+- Configure in your `settings.json` (`formatOnSave` is optional):
   ```json
   {
     "[ruby]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode",
-      "editor.formatOnSave": true // optional
+      "editor.formatOnSave": true
     }
   }
   ```

--- a/README.md
+++ b/README.md
@@ -178,6 +178,24 @@ inherit_from:
   - node_modules/@prettier/plugin-ruby/rubocop.yml
 ```
 
+## Editor Integration
+
+### VS Code
+
+- Add the npm `@prettier/plugin-ruby` package to your project as described above.
+- Install the [Prettier - Code Formatter](https://github.com/prettier/prettier-vscode) extension.
+- Configure in your `settings.json`:
+  ```json
+  {
+    "[ruby]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode",
+      "editor.formatOnSave": true // optional
+    }
+  }
+  ```
+
+Refer to https://github.com/prettier/plugin-ruby/issues/113#issuecomment-783426539 if you're having difficulties.
+
 ## Contributing
 
 Check out our [contributing guide](CONTRIBUTING.md). Bug reports and pull requests are welcome on GitHub at https://github.com/prettier/plugin-ruby.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ inherit_from:
   }
   ```
 
-Refer to https://github.com/prettier/plugin-ruby/issues/113#issuecomment-783426539 if you're having difficulties.
+Refer to [this issue](https://github.com/prettier/plugin-ruby/issues/113#issuecomment-783426539) if you're having difficulties.
 
 ## Contributing
 


### PR DESCRIPTION
I had a lot trouble getting prettier working with VS Code. Initially I was trying to use the Ruby gem, but it seems the npm library is a better choice. 

The approach I describe is based on @coisnepe's comment in https://github.com/prettier/plugin-ruby/issues/113.