### PR TITLE
Remove automatic merging of dependabot pull requests for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Main
 on:
   - push
-  - pull_request_target
+  - pull_request
 jobs:
   ci:
     name: CI

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,20 +68,3 @@ jobs:
       - run: |
           yarn check-format
           yarn lint
-
-  automerge:
-    name: Auto Merge
-    needs:
-      - ci
-      - lint
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
-    steps:
-      - uses: actions/github-script@v3
-        with:
-          script: |
-            github.pulls.merge({
-              owner: context.payload.repository.owner.login,
-              repo: context.payload.repository.name,
-              pull_number: context.payload.pull_request.number
-            })


### PR DESCRIPTION
This workflow is broken as it runs the CI steps in the commit that is in the base branch, not in the commit of the pull request itself.

In addition, this PR reverts commit a10a83c6898741dc99287cec94f2bec2da7dd0c5 which changed the CI to be triggered from `pull_request` to `pull_request_target` event.

Quoting from https://securitylab.github.com/research/github-actions-preventing-pwn-requests/:

> We have also noticed a pattern that has a vulnerable intent of use, however due to misunderstanding of `pull_request_target` ends up being a broken, but not vulnerable, workflow. In these cases, repositories switched to using the `pull_request_target` trigger, but use the default values for the `actions/checkout` action

It seems that this is indeed the case that was happening in this repository after the previously-working Auto Merge functionality stopped to work in https://github.com/prettier/plugin-ruby/pull/845 when it used to work in https://github.com/prettier/plugin-ruby/pull/832 a few weeks earlier.