### PR TITLE
Enable Dependabot automerge in a safe way

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,54 @@
+name: Auto Merge pull requests
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: ["Main"]
+    types:
+      - completed
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    # Only run if workflow completed successfully in a pull request made by dependabot
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.sender.login == 'dependabot[bot]'
+    steps:
+      - name: "Download artifact"
+        uses: actions/github-script@v3
+        with:
+          # Artifact unzip code based on code in
+          # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pre-automerge"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pre-automerge.zip', Buffer.from(download.data));
+      - run: unzip pre-automerge.zip
+      - name: "Merge pull request"
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./PRE_AUTOMERGE_PULL_REQUEST_NUMBER'));
+            await github.pulls.merge({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              pull_number: issue_number
+            })

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -29,7 +29,7 @@ jobs:
                run_id: ${{github.event.workflow_run.id }},
             });
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "pre-automerge"
+              return artifact.name == "save-pr-info"
             })[0];
             var download = await github.actions.downloadArtifact({
                owner: context.repo.owner,
@@ -38,15 +38,15 @@ jobs:
                archive_format: 'zip',
             });
             var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/pre-automerge.zip', Buffer.from(download.data));
-      - run: unzip pre-automerge.zip
+            fs.writeFileSync('${{github.workspace}}/save-pr-info.zip', Buffer.from(download.data));
+      - run: unzip save-pr-info.zip
       - name: "Merge pull request"
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             var fs = require('fs');
-            var issue_number = Number(fs.readFileSync('./PRE_AUTOMERGE_PULL_REQUEST_NUMBER'));
+            var issue_number = Number(fs.readFileSync('./PULL_REQUEST_NUMBER'));
             await github.pulls.merge({
               owner: context.payload.repository.owner.login,
               repo: context.payload.repository.name,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,3 +68,20 @@ jobs:
       - run: |
           yarn check-format
           yarn lint
+
+  pre-automerge:
+    name: Setup for Auto Merge
+    needs:
+      - ci
+      - lint
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+    steps:
+      - name: Save PR number
+        run: |
+          mkdir -p ./pre-automerge
+          echo ${{ github.event.number }} > ./pre-automerge/PRE_AUTOMERGE_PULL_REQUEST_NUMBER
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pre-automerge
+          path: pre-automerge/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
       - ci
       - lint
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+    if: github.event_name == 'pull_request'
     steps:
       - name: Save PR number
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Main
 on:
   - push
-  - pull_request_target
+  - pull_request
 jobs:
   ci:
     name: CI

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,8 +69,10 @@ jobs:
           yarn check-format
           yarn lint
 
-  pre-automerge:
-    name: Setup for Auto Merge
+  # Saves pull request details for later workflow runs which can run in
+  # a privileged environment
+  save-pr-info:
+    name: Save PR info
     needs:
       - ci
       - lint
@@ -79,9 +81,9 @@ jobs:
     steps:
       - name: Save PR number
         run: |
-          mkdir -p ./pre-automerge
-          echo ${{ github.event.number }} > ./pre-automerge/PRE_AUTOMERGE_PULL_REQUEST_NUMBER
+          mkdir -p ./save-pr-info
+          echo ${{ github.event.number }} > ./save-pr-info/PULL_REQUEST_NUMBER
       - uses: actions/upload-artifact@v2
         with:
-          name: pre-automerge
-          path: pre-automerge/
+          name: save-pr-info
+          path: save-pr-info/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,20 +68,3 @@ jobs:
       - run: |
           yarn check-format
           yarn lint
-
-  automerge:
-    name: Auto Merge
-    needs:
-      - ci
-      - lint
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
-    steps:
-      - uses: actions/github-script@v3
-        with:
-          script: |
-            github.pulls.merge({
-              owner: context.payload.repository.owner.login,
-              repo: context.payload.repository.name,
-              pull_number: context.payload.pull_request.number
-            })


### PR DESCRIPTION
This PR starts where https://github.com/prettier/plugin-ruby/pull/879 ended and rewrites the Dependabot pull request automatic merging in a safe way as described in https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

I have tested that this works with https://github.com/valscion/plugin-ruby/pull/4 — the only thing I've changed to make that pull request auto-merged was this one: https://github.com/valscion/plugin-ruby/commit/a972f7eb94f64c97da8c9b64fba81fd78c21dfb1