### PR TITLE
Re-enable `Layout/LineLength`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -4,6 +4,15 @@
 Layout:
   Enabled: false
 
+# Re-enable Layout/LineLength because certain cops that most projects use
+# (e.g. Style/IfUnlessModifier) require Layout/LineLength to be enabled.
+# By leaving it disabled, those rules will mis-fire.
+#
+# Users can always override these defaults in their own rubocop.yml files.
+# https://github.com/prettier/plugin-ruby/issues/825
+Layout/LineLength:
+  Enabled: true
+
 # Disabling all of the following options because they could conflict with a
 # prettier configuration setting.
 


### PR DESCRIPTION
As noted in https://github.com/prettier/plugin-ruby/issues/825, the current Rubocop overrides cause the `Style/IfUnlessModifier` cop to misfire because if `Layout/LineLength` is unset, it assumes that the line length is infinite. 

Prettier disables all `Layout/*` cops which causes the issue above. This keeps all `Layout/*` cops disabled except `Layout/LineLength`.
