### PR TITLE
Group together `.where.not` calls in method chains.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Changed
+
+- [#862](https://github.com/prettier/plugin-ruby/issues/862) - azz, kddeisz - Group together `.where.not` calls in method chains.
+
 ## [1.6.0] - 2021-06-23
 
 ### Added

--- a/src/ruby/nodes/calls.js
+++ b/src/ruby/nodes/calls.js
@@ -33,11 +33,22 @@ function printCall(path, opts, print) {
 
   // The right side of the call node, as in everything including the operator
   // and beyond.
-  const rightSideDoc = concat([
+  let rightSideDoc = concat([
     receiverNode.comments ? hardline : softline,
     operatorDoc,
     messageDoc
   ]);
+
+  // This is very specialized behavior wherein we group .where.not calls
+  // together because it looks better. For more information, see
+  // https://github.com/prettier/plugin-ruby/issues/862.
+  if (
+    receiverNode.type === "call" &&
+    receiverNode.body[2].body === "where" &&
+    messageDoc === "not"
+  ) {
+    rightSideDoc = concat([operatorDoc, messageDoc]);
+  }
 
   // Get a reference to the parent node so we can check if we're inside a chain
   const parentNode = path.getParentNode();

--- a/test/js/ruby/nodes/calls.test.js
+++ b/test/js/ruby/nodes/calls.test.js
@@ -64,6 +64,19 @@ describe("calls", () => {
     return expect(content).toMatchFormat();
   });
 
+  test("chains which contain a .where.not", () => {
+    const content = ruby(`
+      Customer
+        .active
+        .where(foo: 'bar')
+        .where.not(banned_at: nil)
+        .order(created_at: 'desc')
+        .limit(10)
+    `);
+
+    return expect(content).toMatchFormat();
+  });
+
   test("no explicit call doesn't add call", () =>
     expect("a.(1, 2, 3)").toMatchFormat());
 


### PR DESCRIPTION
Fixes #862