### PR TITLE
Ensure all the necessary files are in the gem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: 12.x
       - id: yarn-cache
@@ -54,7 +54,7 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: "3.0"
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: 12.x
       - id: yarn-cache
@@ -68,6 +68,31 @@ jobs:
       - run: |
           yarn check-format
           yarn lint
+
+  gem:
+    name: Gem
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: "3.0"
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+      - id: yarn-cache
+        run: echo "::set-output name=directory::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.directory }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn-
+      - run: yarn install --frozen-lockfile
+      - run: |
+          gem build -o prettier.gem
+          gem unpack prettier.gem
+          prettier/exe/rbprettier --help
 
   # Saves pull request details for later workflow runs which can run in
   # a privileged environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - [#862](https://github.com/prettier/plugin-ruby/issues/862) - azz, kddeisz - Group together `.where.not` calls in method chains.
 - [#863](https://github.com/prettier/plugin-ruby/issues/863) - azz, kddeisz - Fix up Sorbet `sig` block formatting when chaining method calls.
 - [#908](https://github.com/prettier/plugin-ruby/issues/908) - Hansenq, kddeisz - Method chains with blocks should be properly indented.
+- [#916](https://github.com/prettier/plugin-ruby/issues/916) - pbrisbin, kddeisz - Ensure all of the necessary files are present in the gem.
 
 ## [1.6.0] - 2021-06-23
 

--- a/prettier.gemspec
+++ b/prettier.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
       %w[LICENSE bin/console package.json rubocop.yml] +
         Dir['{{exe,lib,src}/**/*,*.md}'] +
         Dir[
-          'node_modules/prettier/{index,bin-prettier,third-party,parser-*}.js'
+          'node_modules/prettier/{package.json,index.js,doc.js,bin-prettier.js,third-party.js,parser-*.js}'
         ]
     end
 


### PR DESCRIPTION
This makes sure the package.json and doc.js are present in the gem (now necessary for latest prettier). It also adds a CI step to check this in the future.

Fixes #916.