### PR TITLE
Ensure hash keys with dynamic symbols do not strip their quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - [#863](https://github.com/prettier/plugin-ruby/issues/863) - azz, kddeisz - Fix up Sorbet `sig` block formatting when chaining method calls.
 - [#908](https://github.com/prettier/plugin-ruby/issues/908) - Hansenq, kddeisz - Method chains with blocks should be properly indented.
 - [#916](https://github.com/prettier/plugin-ruby/issues/916) - pbrisbin, kddeisz - Ensure all of the necessary files are present in the gem.
+- [#917](https://github.com/prettier/plugin-ruby/issues/917) - jscheid, kddeisz - Ensure hash keys with dynamic symbols don't strip their quotes.
 
 ## [1.6.0] - 2021-06-23
 

--- a/src/ruby/nodes/strings.js
+++ b/src/ruby/nodes/strings.js
@@ -152,8 +152,10 @@ function printDynaSymbol(path, opts, print) {
   if (isQuoteLocked(node)) {
     if (node.quote.startsWith("%")) {
       quote = opts.rubySingleQuote ? "'" : '"';
-    } else {
+    } else if (node.quote.startsWith(":")) {
       quote = node.quote.slice(1);
+    } else {
+      quote = node.quote;
     }
   } else {
     quote = opts.rubySingleQuote && isSingleQuotable(node) ? "'" : '"';

--- a/test/js/globalSetup.js
+++ b/test/js/globalSetup.js
@@ -9,7 +9,7 @@ process.env.RUBY_VERSION = spawnSync("ruby", args).stdout.toString().trim();
 // it to get back the AST.
 function globalSetup() {
   if (!process.env.PRETTIER_RUBY_HOST) {
-    process.env.PRETTIER_RUBY_HOST = `/tmp/prettier-ruby-test-${process.id}.sock`;
+    process.env.PRETTIER_RUBY_HOST = `/tmp/prettier-ruby-test-${process.pid}.sock`;
   }
 
   global.__ASYNC_PARSER__ = spawn("ruby", [

--- a/test/js/ruby/nodes/strings.test.js
+++ b/test/js/ruby/nodes/strings.test.js
@@ -196,6 +196,9 @@ describe("strings", () => {
         rubySingleQuote: false
       }));
 
+    test("symbol literal as a hash key", () =>
+      expect("{ '\\d' => 1 }").toMatchFormat());
+
     test("%s literal with newlines", () => {
       const content = ruby(`
         a = %s[


### PR DESCRIPTION
Fixes #917 