### PR TITLE
Don't insert double modifiers on the same line

### DIFF
--- a/src/ruby/nodes/conditionals.js
+++ b/src/ruby/nodes/conditionals.js
@@ -10,6 +10,7 @@ const {
 } = require("../../prettier");
 
 const { containsAssignment, isEmptyStmts } = require("../../utils");
+const containsSingleConditional = require("../../utils/containsSingleConditional");
 const inlineEnsureParens = require("../../utils/inlineEnsureParens");
 
 const printWithAddition = (keyword, path, print, { breaking = false } = {}) =>
@@ -229,10 +230,17 @@ const printConditional =
       ]);
     }
 
-    // If the predicate of the conditional contains an assignment, then we can't
-    // know for sure that it doesn't impact the body of the conditional, so we
-    // have to default to the block form.
-    if (containsAssignment(predicate)) {
+    // Two situations in which we need to use the block form:
+    //
+    // 1. If the predicate of the conditional contains an assignment, then we can't
+    // know for sure that it doesn't impact the body of the conditional.
+    //
+    // 2. If the conditional contains just another conditional, then collapsing it
+    // would result in double modifiers on the same line.
+    if (
+      containsAssignment(predicate) ||
+      containsSingleConditional(statements)
+    ) {
       return concat([
         `${keyword} `,
         align(keyword.length + 1, path.call(print, "body", 0)),

--- a/src/utils/containsSingleConditional.js
+++ b/src/utils/containsSingleConditional.js
@@ -1,0 +1,9 @@
+// If the statements are just a single if/unless, in block or modifier form
+function containsSingleConditional(statements) {
+  return (
+    statements.body.length === 1 &&
+    ["if", "if_mod", "unless", "unless_mod"].includes(statements.body[0].type)
+  );
+}
+
+module.exports = containsSingleConditional;

--- a/test/js/ruby/nodes/conditionals.test.js
+++ b/test/js/ruby/nodes/conditionals.test.js
@@ -1,6 +1,6 @@
 const { long, ruby } = require("../../utils");
 
-describe.skip("conditionals", () => {
+describe("conditionals", () => {
   describe("not operator", () => {
     // from ruby test/ruby/test_not.rb
     test("not operator, empty parens", () =>
@@ -57,6 +57,38 @@ describe.skip("conditionals", () => {
 
         return expect(content).toChangeFormat(expected);
       });
+    });
+
+    test("does not insert double modifiers on a single line", () => {
+      const content = ruby(`
+        if a
+          do_something unless b
+        end
+      `);
+      const expected = ruby(`
+        if a
+          do_something unless b
+        end
+      `);
+
+      return expect(content).toChangeFormat(expected);
+    });
+
+    test("does not insert double modifiers on a single line for nested conditionals", () => {
+      const content = ruby(`
+        if a
+          unless b
+            do_something
+          end
+        end
+      `);
+      const expected = ruby(`
+        if a
+          do_something unless b
+        end
+      `);
+
+      return expect(content).toChangeFormat(expected);
     });
   });
 


### PR DESCRIPTION
With simple nested conditionals, `prettier-ruby` can end up inserting two modifier statements on the same line.  For example:

```ruby
if a
  unless b
    do_something
  end
end
```

turns into:

```ruby
do_something unless b if a
```

This is confusing to read even if you understand the precedence order, and Rubocop has a rule specifically banning this.  This PR adds a check in the conditional printer to make it use block form if the body contains just a single conditional (in either block or modifier form).

While writing tests for this, we noticed the entire conditionals suite was skipped; not sure if this was intentional or not.  We turned it back on for testing and it does pass, so we left it on in the PR, but can re-skip if that's not desired.