### PR TITLE
Don't allow heredocs in a ternary

### DIFF
--- a/src/ruby/nodes/conditionals.js
+++ b/src/ruby/nodes/conditionals.js
@@ -129,6 +129,7 @@ const noTernary = [
   "break",
   "command",
   "command_call",
+  "heredoc",
   "if_mod",
   "ifop",
   "lambda",

--- a/test/js/ruby/nodes/conditionals.test.js
+++ b/test/js/ruby/nodes/conditionals.test.js
@@ -1,6 +1,6 @@
 const { long, ruby } = require("../../utils");
 
-describe.skip("conditionals", () => {
+describe("conditionals", () => {
   describe("not operator", () => {
     // from ruby test/ruby/test_not.rb
     test("not operator, empty parens", () =>
@@ -450,6 +450,36 @@ describe.skip("conditionals", () => {
             b(1)
           else
             b.b 2
+          end
+        `);
+
+        return expect(content).toMatchFormat();
+      });
+
+      test("heredoc in if body", () => {
+        const content = ruby(`
+          if a
+            <<~HEREDOC
+              a
+              b
+            HEREDOC
+          else
+            b
+          end
+        `);
+
+        return expect(content).toMatchFormat();
+      });
+
+      test("heredoc in else body", () => {
+        const content = ruby(`
+          if a
+            a
+          else
+            <<~HEREDOC
+              a
+              b
+            HEREDOC
           end
         `);
 


### PR DESCRIPTION
Fixes #922 by adding `heredoc` to the list of node types that are not allowed in ternary statements.

Ruby style guide recommends [avoiding multi-line ternaries](https://github.com/rubocop/ruby-style-guide#multi-line-ternary-operator). One could make an argument that `heredoc`s are actually one line, but it's hard to read especially when the `heredoc` is in the `if` body.