### PR TITLE
Embedded formatter indentation fixes

### DIFF
--- a/src/ruby/embed.ts
+++ b/src/ruby/embed.ts
@@ -2,8 +2,15 @@ import type { Plugin, Ruby } from "../types";
 import prettier from "../prettier";
 import { literallineWithoutBreakParent } from "../utils";
 
-const { group, indent, lineSuffix, mapDoc, markAsRoot, stripTrailingHardline } =
-  prettier;
+const {
+  group,
+  indent,
+  dedent,
+  lineSuffix,
+  mapDoc,
+  markAsRoot,
+  stripTrailingHardline
+} = prettier;
 
 const parsers: Record<string, string> = {
   css: "css",
@@ -47,6 +54,7 @@ function getCommonLeadingWhitespace(content: string) {
   return content
     .split("\n")
     .slice(0, -1)
+    .filter((line) => line.trim().length > 0)
     .reduce((minimum, line) => {
       const matched = pattern.exec(line);
       const length = matched ? matched[0].length : 0;
@@ -109,9 +117,9 @@ const embed: Plugin.Embed<Ruby.AnyNode> = (path, print, textToDoc) => {
     return [
       path.call(print, "beging"),
       lineSuffix(
-        group([
+        dedent([
           indent(markAsRoot(formatted)),
-          literallineWithoutBreakParent,
+          { type: "line", hard: true },
           ending.trim()
         ])
       )

--- a/test/js/ruby/embed.test.ts
+++ b/test/js/ruby/embed.test.ts
@@ -78,4 +78,66 @@ describe("embed", () => {
 
     return expect(content).toChangeFormat(expected);
   });
+
+  test("keeps parent indentation", () => {
+    const content = ruby(`
+      some_block do
+        another_block do
+          x += 1
+          description <<~JS
+            // This is a DSL method on the another_block inner block.
+            // This is another line of the string.
+          JS
+        end
+      end
+    `);
+
+    return expect(content).toMatchFormat();
+  });
+
+  test("correctly indents nested code while keeping parent indentation", () => {
+    const content = ruby(`
+      some_block do
+        another_block do
+          x += 1
+          description <<~JS
+            [1, function () { return 2; }, 3];
+          JS
+        end
+      end
+    `);
+    const expected = ruby(`
+      some_block do
+        another_block do
+          x += 1
+          description <<~JS
+            [
+              1,
+              function () {
+                return 2;
+              },
+              3
+            ];
+          JS
+        end
+      end
+    `);
+
+    return expect(content).toChangeFormat(expected);
+  });
+
+  test("doesn't consider empty lines as part of the common leading whitespace", () => {
+    const content = ruby(`
+      some_block do
+        x += 1
+        description <<~MARKDOWN
+          This is a line. It's followed by two literal line breaks.
+
+          This is another line of the string.
+        MARKDOWN
+      end
+    `);
+
+    return expect(content).toMatchFormat();
+  });
 });


### PR DESCRIPTION
This fixes two separate, but related, issues in embedded language formatting for heredocs:

First: the `getCommonLeadingWhitespace` function was considering empty lines as part of the calculation.  Some editors (and possibly prettier itself?) strip trailing whitespace from lines, so an empty line in a heredoc might have zero length and therefore shouldn't be considered part of the common leading whitespace.

Second: the content of the heredoc, and the ending, are indented to the level where the heredoc starts, not the beginning of that line.  So, for example:

```ruby
do_something <<~JS
  1 + 2;
JS
```

becomes:

```ruby
do_something <<~JS
               1 + 2;
             JS
```

It seems as if inserting a `dedent` command inside the `lineSuffix` command fixes this behavior, but I'm not totally sure I understand the prettier printer in enough detail to explain why.  I arrived at that solution while pairing with @jennceng, pretty much by trial and error.

One other change I made that I do understand enough to explain is switching from `literallineWithoutBreakParent` to (the equivalent of) `hardlineWithoutBreakParent`.  Without it, the ending of the heredoc ends up all the way dedented, whereas with it, it ends up on the same indentation level as the line containing the heredoc beginning.  Which sort of seems like how hard line breaks are supposed to work!

---

Previous version of this for posterity, when I had a fix that worked some of the time for the outer indentation thing, but which turned out to be both a little scary and trivially defeated:

~Embedded formatters were sometimes inserting `break-parent`, which messes up outer indentation of the heredoc.  This is a little hard to describe, and I'm not 100% confident I entirely understand what the prettier printer is doing here, but the included test cases reproduce the issue.  Without stripping out `break-parent` commands, the embedded content is indented two spaces beyond the heredoc beginning, and the ending is always outdented all the way.~
