### PR TITLE
Use block form when there's a ternary inside a conditional

### DIFF
--- a/src/utils/containsSingleConditional.js
+++ b/src/utils/containsSingleConditional.js
@@ -1,8 +1,10 @@
-// If the statements are just a single if/unless, in block or modifier form
+// If the statements are just a single if/unless, in block or modifier form, or a ternary
 function containsSingleConditional(statements) {
   return (
     statements.body.length === 1 &&
-    ["if", "if_mod", "unless", "unless_mod"].includes(statements.body[0].type)
+    ["if", "if_mod", "ifop", "unless", "unless_mod"].includes(
+      statements.body[0].type
+    )
   );
 }
 

--- a/test/js/ruby/nodes/conditionals.test.js
+++ b/test/js/ruby/nodes/conditionals.test.js
@@ -565,6 +565,28 @@ describe("conditionals", () => {
         return expect(content).toChangeFormat(expected);
       });
 
+      test("nested ternary in if body", () => {
+        const content = ruby(`
+          if a
+            b ? c : d
+          end
+        `);
+
+        return expect(content).toMatchFormat();
+      });
+
+      test("nested ternary in else body", () => {
+        const content = ruby(`
+          if a
+            b
+          else
+            c ? d : e
+          end
+        `);
+
+        return expect(content).toMatchFormat();
+      });
+
       test("command with argument predicate", () => {
         const content = ruby(`
           if a b


### PR DESCRIPTION
This is the fix for the inverse case of #933.  Currently, prettier-plugin-ruby will turn this:

```ruby
if a
  b ? c : d
end
```

into this:

```ruby
b ? c : d if a
```

which Rubocop disallows, and is also pretty confusing to read IMO.  With this fix, it will consider a ternary to be a type of single-conditional and therefore use block form (which means that the first example would pass through prettier unchanged).