### PR TITLE
Throw away stderr when testing candidate connection methods

### DIFF
--- a/src/parser/server.rb
+++ b/src/parser/server.rb
@@ -112,7 +112,7 @@ candidates.map! do |candidate|
   Thread.new do
     Thread.current.report_on_exception = false
 
-    stdout, status =
+    stdout, _stderr, status =
       Open3.capture2("#{candidate} #{information}", stdin_data: 'ping')
 
     candidate if JSON.parse(stdout) == 'pong' && status.exitstatus == 0


### PR DESCRIPTION
This mirrors the way the plugin worked in v1.x where it also ignored stderr when doing this check on the Node side.

Fixes https://github.com/prettier/plugin-ruby/issues/985