### PR TITLE
Throw away stderr when testing candidate connection methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Changed
+
+- [#987](https://github.com/prettier/plugin-ruby/pull/9870) - valscion - Ignore stderr when checking for node <-> ruby connection clients, restoring the behavior of v1.x
+
 ## [2.0.0-rc2]
 
 ### Added

--- a/src/parser/server.rb
+++ b/src/parser/server.rb
@@ -112,8 +112,9 @@ candidates.map! do |candidate|
   Thread.new do
     Thread.current.report_on_exception = false
 
-    stdout, status =
-      Open3.capture2("#{candidate} #{information}", stdin_data: 'ping')
+    # We do not care about stderr here, so throw it away
+    stdout, _stderr, status =
+      Open3.capture3("#{candidate} #{information}", stdin_data: 'ping')
 
     candidate if JSON.parse(stdout) == 'pong' && status.exitstatus == 0
   rescue StandardError


### PR DESCRIPTION
This mirrors the way the plugin worked in v1.x where it also ignored stderr when doing this check on the Node side.

Fixes #985