### PR TITLE
Allow running @prettier/plugin-ruby unplugged

### DIFF
--- a/src/parser/parseSync.ts
+++ b/src/parser/parseSync.ts
@@ -109,11 +109,14 @@ function spawnServer(): ParserArgs {
 // therein are not going to work with its virtual file system. Presumably
 // there's a way to fix this but I haven't figured out how yet.
 function checkPnP() {
-  if (process.versions.pnp) {
+  if (process.versions.pnp && __dirname.includes(".zip")) {
     throw new Error(`
       @prettier/plugin-ruby does not current work within the yarn Plug'n'Play
       virtual file system. If you would like to help support the effort to fix
       this, please see https://github.com/prettier/plugin-ruby/issues/894.
+
+      If you want to use @prettier/plugin-ruby in a PnP environment before
+      this issue is fixed, please run \`yarn unplug @prettier/plugin-ruby\`.
     `);
   }
 }


### PR DESCRIPTION
This doesn't actually fix #894 (although I'm interested in doing that), but it does provide a reasonable workaround for PnP users in the meantime.  If you run `yarn unplug @prettier/plugin-ruby`, which causes yarn to unzip the files for just this package, things do actually work fine (verified this locally).  So I've made the check slightly more lenient here by looking for the thing I think is actually causing the issues with PnP: the fact that the directory the Ruby server is in doesn't actually exist in the filesystem.