### PR TITLE
Don't allow scope resolution operator to be split up

### DIFF
--- a/src/ruby/nodes/constants.ts
+++ b/src/ruby/nodes/constants.ts
@@ -42,5 +42,5 @@ export const printField: Plugin.Printer<Ruby.Field> = (path, opts, print) => {
 export const printTopConst: Plugin.Printer<
   Ruby.TopConstField | Ruby.TopConstRef
 > = (path, opts, print) => {
-  return ["::", path.call(print, "body", 0)];
+  return group(["::", path.call(print, "body", 0)], { shouldBreak: false });
 };

--- a/test/js/ruby/nodes/rescue.test.ts
+++ b/test/js/ruby/nodes/rescue.test.ts
@@ -38,6 +38,18 @@ describe("rescue", () => {
     expect(content).toMatchFormat();
   });
 
+  test("errors with scope resolution operator", () => {
+    const content = ruby(`
+      def foo
+        a
+      rescue ::A
+        e
+      end
+    `);
+
+    expect(content).toMatchFormat();
+  });
+
   test.each(["begin", "def foo"])("%s with every clause", (declaration) => {
     const error = "BreakingBreakingBreakingBreakingBreakingError";
     const content = ruby(`


### PR DESCRIPTION
This fixes a bad interaction between `rescue` and the top scope resolution operator.  Without this fix, this code:

```ruby
def foo
  a
rescue ::A
  e
end
```

will become:

```ruby
def foo
  a
rescue ::, A
  e
end
```