### PR TITLE
Fix support for piping STDIN

### DIFF
--- a/lib/prettier.rb
+++ b/lib/prettier.rb
@@ -12,7 +12,11 @@ module Prettier
     quoted = args.map { |arg| arg.start_with?('-') ? arg : "\"#{arg}\"" }
     command = "node #{BINARY} --plugin \"#{PLUGIN}\" #{quoted.join(' ')}"
 
-    stdout, stderr, status = Open3.capture3({ 'RBPRETTIER' => '1' }, command)
+    stdout, stderr, status = Open3.capture3(
+      { 'RBPRETTIER' => '1' },
+      command,
+      stdin_data: STDIN
+    )
     STDOUT.puts(stdout)
 
     # If we completed successfully, then just exit out.


### PR DESCRIPTION
Since the change to Open3 `STDIN` is not sent to prettier, so formatting produces an empty output.

This sets the `:stdin_data` option to pass Open3 the `STDIN`.

The previous use of `system` seems to have implicitly used the parent `STDIN`.