### PR TITLE
More consistent assignment indentation

### DIFF
--- a/src/ruby/nodes/assign.ts
+++ b/src/ruby/nodes/assign.ts
@@ -1,10 +1,29 @@
 import type { Plugin, Ruby } from "../../types";
 import prettier from "../../prettier";
 import { skipAssignIndent } from "../../utils";
+import { Doc, Path } from "../../types/plugin";
 
 const { group, indent, join, line } = prettier;
 
-export const printAssign: Plugin.Printer<Ruby.Assign> = (path, opts, print) => {
+export const printAssign: Plugin.Printer<Ruby.Assign> = (...args) => {
+  return printOpAssignOrAssign("=", ...args);
+};
+
+export const printOpAssign: Plugin.Printer<Ruby.Opassign | Ruby.Assign> = (
+  path,
+  opts,
+  print
+) => {
+  const opDoc = path.call(print, "op");
+  return printOpAssignOrAssign(opDoc, path, opts, print);
+};
+
+function printOpAssignOrAssign(
+  opDoc: Doc,
+  path: Path<Ruby.Assign | Ruby.Opassign>,
+  opts: Plugin.Options,
+  print: Plugin.Print
+): Doc {
   const valueNode = path.getValue().value;
 
   const targetDoc = path.call(print, "target");
@@ -21,23 +40,11 @@ export const printAssign: Plugin.Printer<Ruby.Assign> = (path, opts, print) => {
   }
 
   if (skipAssignIndent(valueNode)) {
-    return group([targetDoc, " = ", rightSideDoc]);
+    return group([targetDoc, " ", opDoc, " ", rightSideDoc]);
   }
 
-  return group([targetDoc, " =", indent([line, rightSideDoc])]);
-};
-
-export const printOpAssign: Plugin.Printer<Ruby.Opassign> = (
-  path,
-  opts,
-  print
-) =>
-  group([
-    path.call(print, "target"),
-    " ",
-    path.call(print, "op"),
-    indent([line, path.call(print, "value")])
-  ]);
+  return group([targetDoc, " ", opDoc, indent([line, rightSideDoc])]);
+}
 
 export const printVarField: Plugin.Printer<Ruby.VarField> = (
   path,

--- a/src/utils/skipAssignIndent.ts
+++ b/src/utils/skipAssignIndent.ts
@@ -6,7 +6,11 @@ const skippable = [
   "hash",
   "heredoc",
   "lambda",
-  "regexp_literal"
+  "qsymbols",
+  "qwords",
+  "regexp_literal",
+  "symbols",
+  "words"
 ];
 
 function skipAssignIndent(node: Ruby.AnyNode): boolean {

--- a/test/js/ruby/nodes/assign.test.ts
+++ b/test/js/ruby/nodes/assign.test.ts
@@ -64,6 +64,21 @@ describe("assign", () => {
       );
     });
 
+    describe("assignments from quotewords and similar", () => {
+      const cases = ["w", "W", "i", "I"];
+
+      test.each(cases)("x = %s[...] is not force-indented", (literal) => {
+        expect(`a = %${literal}[${long} ${long}]`).toChangeFormat(
+          ruby(`
+            a = %${literal}[
+              ${long}
+              ${long}
+            ]
+          `)
+        );
+      });
+    });
+
     test("chained methods on array literals don't get oddly indented", () => {
       expect(`a = [${long}].freeze`).toChangeFormat(
         ruby(`

--- a/test/js/ruby/nodes/assign.test.ts
+++ b/test/js/ruby/nodes/assign.test.ts
@@ -84,6 +84,40 @@ describe("assign", () => {
         `)
       );
     });
+
+    describe("assignment operators", () => {
+      // some but not all
+      const operators = ["||", "&&", "+", "*", "%", "**", "<<"];
+
+      test.each(operators)("array %s= [...] is not force-indented", (op) => {
+        expect(`a ${op}= [${long}, ${long}, ${long}]`).toChangeFormat(
+          ruby(`
+            a ${op}= [
+              ${long},
+              ${long},
+              ${long}
+            ]
+          `)
+        );
+      });
+
+      test.each(operators)("hash %s= { ... } is not force-indented", (op) => {
+        expect(
+          `a ${op}= { a: ${long}, b: ${long}, c: ${long} }`
+        ).toChangeFormat(
+          ruby(`
+          a ${op}= {
+            a:
+              ${long},
+            b:
+              ${long},
+            c:
+              ${long}
+          }
+          `)
+        );
+      });
+    });
   });
 
   describe("constants", () => {


### PR DESCRIPTION
Currently there's some special handling when the rhs of an assignment is a collection literal - the newline + indentation after the `=` doesn't get added.

e.g. prettier does this:
```ruby
hash = { 
  # ...
```
not this:
```ruby
hash = 
  { 
    # ...
```

This PR expands this to a couple of scenarios where it probably should have been happening but wasn't:

**Operator + Assignment**

prior behavior:
```ruby
hash ||= 
  { 
    # ...
```

new behavior:
```ruby
hash ||= { 
  # ...
```

**Quotewords-style Collection Literal**


prior behavior:
```ruby
arr = 
  %i[
    thing1
    thing2
    # ...
  ]
```

new behavior:
```ruby
arr = %i[
  thing1
  thing2
  # ...
]
```

I think there's a case to be made that _non_-collection literals should work similarly (regexes and dynamic symbols already do) but that seems like less of an easy win.