### PR TITLE
Basic Support for Ruby 3.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
     runs-on: ${{ matrix.platform }}
     env:
       PLUGIN_RUBY_CI: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,8 +178,20 @@ The first are JavaScript tests (run with `jest`) that test the formatting agains
 $ yarn test
 ```
 
+Run an individual test like this:
+
+```
+$ yarn test test/js/ruby/nodes/assign.test.ts -t "assign single assignment basic"
+```
+
 The second are Ruby tests (run with `minitest`) that test the gem the wraps the `prettier` plugin as well as testing the various metadata attached to the AST nodes that `ripper` generates. They live in [test/rb](test/rb). To run them, run:
 
 ```
 $ bundle exec rake
+```
+
+Run an individual test like this:
+
+```
+$ ruby -Itest/rb test/rb/metadata_test.rb --name test_fcall
 ```

--- a/src/ruby/parser.rb
+++ b/src/ruby/parser.rb
@@ -5902,7 +5902,7 @@ class SyntaxTree < Ripper
       *posts,
       *keywords&.flat_map { |(key, value)| [key, value || nil] },
       (keyword_rest if keyword_rest != :nil),
-      block
+      (block if block != :&)
     ].compact
 
     location =
@@ -5919,7 +5919,7 @@ class SyntaxTree < Ripper
       posts: posts || [],
       keywords: keywords || [],
       keyword_rest: keyword_rest,
-      block: block,
+      block: (block if block != :&),
       location: location
     )
   end

--- a/src/ruby/parser.rb
+++ b/src/ruby/parser.rb
@@ -5911,6 +5911,13 @@ class SyntaxTree < Ripper
       else
         Location.fixed(line: lineno, char: char_pos)
       end
+    
+    # 3.1 puts "..." in keyword_rest rather than rest
+    # https://github.com/ruby/ruby/commit/13a9597c7ca83fced5738e9345660ae6aef87eb7
+    if !rest && keyword_rest.is_a?(ArgsForward)
+      rest = keyword_rest
+      keyword_rest = nil
+    end
 
     Params.new(
       requireds: requireds || [],

--- a/src/ruby/parser.rb
+++ b/src/ruby/parser.rb
@@ -2730,10 +2730,10 @@ class SyntaxTree < Ripper
     # Find the beginning of the method definition, which works for single-line
     # and normal method definitions.
     beginning = find_token(Kw, 'def')
-    
-    is_endless = 
-      !bodystmt.is_a?(BodyStmt) || # ruby 3.0
-      !bodystmt.statements.is_a?(Statements) # ruby 3.1
+
+    # ruby 3.0 check || ruby 3.1 check
+    is_endless =
+      !bodystmt.is_a?(BodyStmt) || !bodystmt.statements.is_a?(Statements)
 
     # If we don't have a bodystmt node, then we have a single-line method
     if is_endless
@@ -5916,7 +5916,7 @@ class SyntaxTree < Ripper
       else
         Location.fixed(line: lineno, char: char_pos)
       end
-    
+
     # 3.1 puts "..." in keyword_rest rather than rest
     # https://github.com/ruby/ruby/commit/13a9597c7ca83fced5738e9345660ae6aef87eb7
     if !rest && keyword_rest.is_a?(ArgsForward)

--- a/src/ruby/parser.rb
+++ b/src/ruby/parser.rb
@@ -2730,13 +2730,18 @@ class SyntaxTree < Ripper
     # Find the beginning of the method definition, which works for single-line
     # and normal method definitions.
     beginning = find_token(Kw, 'def')
+    
+    is_endless = 
+      !bodystmt.is_a?(BodyStmt) || # ruby 3.0
+      !bodystmt.statements.is_a?(Statements) # ruby 3.1
 
     # If we don't have a bodystmt node, then we have a single-line method
-    unless bodystmt.is_a?(BodyStmt)
+    if is_endless
       node =
         DefEndless.new(
           name: name,
-          paren: params,
+          # with vs. without parentheses
+          paren: params.is_a?(Paren) ? params : nil,
           statement: bodystmt,
           location: beginning.location.to(bodystmt.location)
         )

--- a/test/rb/metadata_test.rb
+++ b/test/rb/metadata_test.rb
@@ -787,6 +787,21 @@ class MetadataTest < Minitest::Test
     end
   end
 
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')
+    def test_def_endless
+      assert_metadata SyntaxTree::DefEndless, "def foo() = bar"
+    end
+
+    def test_def_endless_no_paren
+      content = "def foo = bar"
+      assert_metadata SyntaxTree::DefEndless, content
+      assert_nil parse(content).paren
+    end
+
+    def test_def_endless_params
+      assert_metadata SyntaxTree::DefEndless, "def foo(a) = bar"
+    end
+  end
   private
 
   def assert_metadata(type, ruby)

--- a/test/rb/metadata_test.rb
+++ b/test/rb/metadata_test.rb
@@ -789,19 +789,20 @@ class MetadataTest < Minitest::Test
 
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')
     def test_def_endless
-      assert_metadata SyntaxTree::DefEndless, "def foo() = bar"
+      assert_metadata SyntaxTree::DefEndless, 'def foo() = bar'
     end
 
     def test_def_endless_no_paren
-      content = "def foo = bar"
+      content = 'def foo = bar'
       assert_metadata SyntaxTree::DefEndless, content
       assert_nil parse(content).paren
     end
 
     def test_def_endless_params
-      assert_metadata SyntaxTree::DefEndless, "def foo(a) = bar"
+      assert_metadata SyntaxTree::DefEndless, 'def foo(a) = bar'
     end
   end
+
   private
 
   def assert_metadata(type, ruby)


### PR DESCRIPTION
Ripper under Ruby 3.1 apparently changed the signatures of handlers for some syntax, even though the syntax itself didn't change. Specifically:
- argument forwarding (`...`)
- "endless" method definitions, with and without parents (`def a = b`, `def a() = b`)

This PR fixes these two issues, so prettier ruby can run under Ruby 3.1 as long as your source code is 3.0 compatible-ish. It _doesn't_ add support for syntax newly added in 3.1, like forwarded blocks, pinned expressions, implicit hash values, etc.

should fix #1129 and #1098
