### PR TITLE
Support rbs 2.x under ruby 3.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
     runs-on: ${{ matrix.platform }}
     env:
       PLUGIN_RUBY_CI: true

--- a/src/rbs/printer.ts
+++ b/src/rbs/printer.ts
@@ -447,30 +447,26 @@ const printer: Plugin.PrinterConfig<RBS.AnyNode> = {
       path: Plugin.Path<RBS.NameAndTypeParams>,
       node: RBS.NameAndTypeParams
     ) {
-      if (node.type_params.params.length === 0) {
+      if (node.type_params.length === 0) {
         return node.name;
       }
 
-      const docs = path.map(
-        (paramPath) => {
-          const node = paramPath.getValue();
-          const parts = [];
+      const docs = path.map((paramPath) => {
+        const node = paramPath.getValue();
+        const parts = [];
 
-          if (node.skip_validation) {
-            parts.push("unchecked");
-          }
+        if (node.unchecked) {
+          parts.push("unchecked");
+        }
 
-          if (node.variance === "covariant") {
-            parts.push("out");
-          } else if (node.variance === "contravariant") {
-            parts.push("in");
-          }
+        if (node.variance === "covariant") {
+          parts.push("out");
+        } else if (node.variance === "contravariant") {
+          parts.push("in");
+        }
 
-          return join(" ", [...parts, node.name]);
-        },
-        "type_params",
-        "params"
-      );
+        return join(" ", [...parts, node.name]);
+      }, "type_params");
 
       return [node.name, "[", join(", ", docs), "]"];
     }
@@ -568,7 +564,9 @@ const printer: Plugin.PrinterConfig<RBS.AnyNode> = {
 
       // We won't have a type_params key if we're printing a block
       if (node.type_params && node.type_params.length > 0) {
-        parts.push("[", join(", ", node.type_params), "] ");
+        const typeParamNames = node.type_params.map((tp) => tp.name);
+
+        parts.push("[", join(", ", typeParamNames), "] ");
       }
 
       const params = path.call(printMethodParams, "type");

--- a/src/rbs/printer.ts
+++ b/src/rbs/printer.ts
@@ -466,9 +466,7 @@ const printer: Plugin.PrinterConfig<RBS.AnyNode> = {
         }
 
         if (node.upper_bound) {
-          const path = paramPath as Plugin.Path<
-            RequiredKeys<RBS.Param, "upper_bound">
-          >;
+          const path = paramPath as Plugin.Path<{ upper_bound: RBS.Type }>;
           const upperBound = path.call(printType, "upper_bound");
           return join(" ", [...parts, node.name, "<", upperBound]);
         } else {

--- a/src/rbs/printer.ts
+++ b/src/rbs/printer.ts
@@ -465,7 +465,15 @@ const printer: Plugin.PrinterConfig<RBS.AnyNode> = {
           parts.push("in");
         }
 
-        return join(" ", [...parts, node.name]);
+        if (node.upper_bound) {
+          const path = paramPath as Plugin.Path<
+            RequiredKeys<RBS.Param, "upper_bound">
+          >;
+          const upperBound = path.call(printType, "upper_bound");
+          return join(" ", [...parts, node.name, "<", upperBound]);
+        } else {
+          return join(" ", [...parts, node.name]);
+        }
       }, "type_params");
 
       return [node.name, "[", join(", ", docs), "]"];

--- a/src/types/rbs.ts
+++ b/src/types/rbs.ts
@@ -18,7 +18,7 @@ export type MethodParams = {
 };
 
 export type MethodSignature = {
-  type_params: string[],
+  type_params: Param[],
   type: MethodParams & { return_type: Type },
   block: { required: boolean } & MethodSignature
 };
@@ -74,13 +74,13 @@ export type MethodDefinition = Member & { member: "method_definition" };
 
 export type Param = {
   name: string,
-  skip_validation: boolean,
+  unchecked: boolean,
   variance: "invariant" | "covariant" | "contravariant"
 };
 
 export type NameAndTypeParams = {
   name: string,
-  type_params: { params: Param[] }
+  type_params: Param[]
 };
 
 export type Class = { declaration: "class", super_class?: NameAndArgs, members: Member[] } & NameAndTypeParams;

--- a/src/types/rbs.ts
+++ b/src/types/rbs.ts
@@ -76,6 +76,7 @@ export type Param = {
   name: string,
   unchecked: boolean,
   variance: "invariant" | "covariant" | "contravariant"
+  upper_bound?: Type, 
 };
 
 export type NameAndTypeParams = {

--- a/test/js/rbs/rbs.test.ts
+++ b/test/js/rbs/rbs.test.ts
@@ -47,6 +47,26 @@ describe("rbs", () => {
       expect(content).toMatchFormat();
     });
 
+    if (atLeastVersion("3.1")) {
+      test("interface with bounded type param", () => {
+        const content = rbs(`
+          interface _Foo[A < B]
+          end
+        `);
+
+        expect(content).toMatchFormat();
+      });
+
+      test("interface with fancy bounded type params", () => {
+        const content = rbs(`
+          interface _Foo[U < singleton(::Hash), V < W[X, Y]]
+          end
+        `);
+
+        expect(content).toMatchFormat();
+      });
+    }
+
     test("class", () => {
       const content = rbs(`
         class Foo
@@ -73,6 +93,26 @@ describe("rbs", () => {
 
       expect(content).toMatchFormat();
     });
+
+    if (atLeastVersion("3.1")) {
+      test("class with bounded type param", () => {
+        const content = rbs(`
+          class Foo[A < B]
+          end
+        `);
+
+        expect(content).toMatchFormat();
+      });
+
+      test("class with fancy bounded type params", () => {
+        const content = rbs(`
+          class Foo[U < singleton(::Hash), V < W[X, Y]]
+          end
+        `);
+
+        expect(content).toMatchFormat();
+      });
+    }
 
     test("class with annotations", () => {
       const content = rbs(`

--- a/test/rb/rbs_test.rb
+++ b/test/rb/rbs_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RBSTest < Minitest::Test
+  # https://github.com/ruby/rbs/commit/c5da467adacc75fe9294ec1630f1b7931d9d6871
+  def test_module_type_params_empty
+    actual = declaration_json("interface _Foo\nend")['type_params']
+    assert_instance_of Array, actual
+    assert_empty actual
+  end
+
+  def test_module_type_params_fancy
+    source = <<~SOURCE
+      class Foo[unchecked in A, B]
+      end
+    SOURCE
+
+    actual = declaration_json(source)['type_params']
+    assert_instance_of Array, actual
+    assert_equal 2, actual.length
+
+    type_a, type_b = actual
+
+    assert_equal 'A', type_a['name']
+    assert_equal 'contravariant', type_a['variance']
+    assert_equal true, type_a['unchecked']
+
+    assert_equal 'B', type_b['name']
+    assert_equal 'invariant', type_b['variance']
+    assert_equal false, type_b['unchecked']
+  end
+
+  # https://github.com/ruby/rbs/commit/3ccdcb1f3ac5dcb866280f745866a852658195e6
+  def test_generic_method
+    source = <<~SOURCE
+      class T
+        def t: [A, B] (A) -> B
+      end
+    SOURCE
+
+    actual = member_json(source)['types'].first['type_params']
+    assert_equal 2, actual.length
+
+    type_a, type_b = actual
+    assert_equal 'A', type_a['name']
+    assert_equal 'B', type_b['name']
+  end
+
+  private
+
+  def declaration_json(source)
+    JSON.parse(first_declaration(source).to_json)
+  end
+
+  def member_json(source)
+    JSON.parse(first_member(source).to_json)
+  end
+
+  def parse(source)
+    Prettier::RBSParser.parse(source)
+  end
+
+  def first_declaration(source)
+    parse(source)[:declarations].first
+  end
+
+  def first_member(source)
+    first_declaration(source).members.first
+  end
+end

--- a/test/rb/test_helper.rb
+++ b/test/rb/test_helper.rb
@@ -4,5 +4,6 @@ $LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
 
 require 'prettier'
 require_relative '../../src/ruby/parser'
+require_relative '../../src/rbs/parser'
 
 require 'minitest/autorun'


### PR DESCRIPTION
Adds support for:
- Bounded type parameters
- Some ast changes made as part of rbs 2

Didn't add support for inline visibility modifiers b/c https://github.com/ruby/rbs/pull/923
Would be easy to monkeypatch though.