### PR TITLE
Fix additional issues with AlpineJS syntax in haml

### DIFF
--- a/src/haml/parser.rb
+++ b/src/haml/parser.rb
@@ -44,12 +44,6 @@ class Haml::Parser::ParseNode
         if hash
           # Explicitly not using Enumerable#to_h here to support Ruby 2.5
           hash.each_with_object({}) do |(key, value), response|
-            # For attributes that starts with @, wrap the attribute in quotes
-            # For other attributes, remove the quotes
-            # AlpineJS uses @-attributes
-            # {'type': 'submit'} => {type: 'submit'}
-            # {'@click': 'open'} => {'@click': 'open'}
-            key = "\'#{key}\'" if key.start_with?('@')
             response[key] = parse_value(value, level + 1)
           end
         else

--- a/src/haml/printer.ts
+++ b/src/haml/printer.ts
@@ -31,7 +31,7 @@ function printHashKey(key: string, opts: Plugin.Options) {
   let quoted = key;
   const joiner = opts.rubyHashLabel ? ":" : " =>";
 
-  if (key.includes(":") || key.includes("-")) {
+  if (key.includes(":") || key.includes("-") || key.includes('@')) {
     const quote = opts.rubySingleQuote ? "'" : '"';
     quoted = `${quote}${key}${quote}`;
   }

--- a/test/js/haml/tag.test.ts
+++ b/test/js/haml/tag.test.ts
@@ -106,6 +106,8 @@ describe("tag", () => {
 
     test("attributes prefixed with @", () => {
       expect(haml("%span{'@click': 'open = true'}")).toMatchFormat();
+      expect(haml("%span{'@click.outside': 'open = true'}")).toMatchFormat();
+      expect(haml("%span{'@keydown.arrow-up.prevent': 'open = true'}")).toMatchFormat();
     });
   });
 


### PR DESCRIPTION
In PR https://github.com/prettier/plugin-ruby/pull/1097, I added support
for haml attributes starting with '@', which are extensively used
in AlpineJS.

However, the PR was incomplete, and did not work in all cases. This
PR adds two jest test cases that fail with the current code, and a fix
that passes all specs.

The fix also collocates @-attributes support with other haml edge cases
(in the printer) instead of hooking into a separate part of the
codebase.