### PR TITLE
Fix PnP

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,8 +58,8 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          # - macos-latest
-          # - ubuntu-latest
+          - macos-latest
+          - ubuntu-latest
           - windows-latest
         yarn:
           - 2.x
@@ -73,6 +73,7 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: "3.1"
+      - run: gem install syntax_tree syntax_tree-haml syntax_tree-rbs
       - uses: actions/setup-node@v2
         with:
           node-version: 12.x

--- a/src/parseSync.js
+++ b/src/parseSync.js
@@ -86,7 +86,7 @@ function spawnServer() {
         mkdirSync(destDir);
       }
       copyFileSync(
-        path.join(__dirname, "..", rubyFile),
+        path.join(__dirname, "..", "src", rubyFile),
         path.join(tempDir, rubyFile)
       );
     });


### PR DESCRIPTION
It turns out that not only was the PnP smoke test broken, PnP itself was broken in UNIX environments.  Actually, I'm a little confused about why it was passing on Windows.

The issue is that the syntax_tree-based plugin doesn't store the source files in the same location in the package as before.  So, the parseSync logic needs to know about that so it can copy the files from the new directory.