### PR TITLE
Fix some tests failing on main

### DIFF
--- a/prettier.gemspec
+++ b/prettier.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables = "rbprettier"
   spec.require_paths = %w[lib]
 
-  spec.add_dependency "syntax_tree", ">= 2.3.1"
+  spec.add_dependency "syntax_tree", ">= 2.7.1"
   spec.add_dependency "syntax_tree-haml", ">= 1.1.0"
   spec.add_dependency "syntax_tree-rbs", ">= 0.2.0"
 

--- a/test/js/ruby/nodes/patterns.test.js
+++ b/test/js/ruby/nodes/patterns.test.js
@@ -15,18 +15,13 @@ describe("patterns", () => {
     "-1..1",
     "Integer",
     "bar",
-    "_, _",
     "0 | 1 | 2",
     "Integer => bar",
     "Object[0, *bar, 1]",
-    "a, b, *c, d, e",
-    "*c, d, e",
-    "0, [1, _] => bar",
     "^bar",
     "{ x: 0.. => px, **rest }",
     "**rest",
-    "SuperPoint[x: 0.. => px]",
-    "a, b if b == a * 2"
+    "SuperPoint[x: 0.. => px]"
   ];
 
   if (atLeastVersion("3.0")) {
@@ -56,6 +51,96 @@ describe("patterns", () => {
     expect(content).toMatchFormat();
   });
 
+  test("a, b, *c, d, e", () => {
+    const content = ruby(`
+      case foo
+      in a, b, *c, d, e
+        baz
+      end
+    `);
+
+    const expectedContent = ruby(`
+      case foo
+      in [a, b, *c, d, e]
+        baz
+      end
+    `);
+
+    expect(content).toChangeFormat(expectedContent);
+  });
+
+  test("0, [1, _] => bar", () => {
+    const content = ruby(`
+      case foo
+      in 0, [1, _] => bar
+        baz
+      end
+    `);
+
+    const expectedContent = ruby(`
+      case foo
+      in [0, [1, _] => bar]
+        baz
+      end
+    `);
+
+    expect(content).toChangeFormat(expectedContent);
+  });
+
+  test("*c, d, e", () => {
+    const content = ruby(`
+      case foo
+      in *c, d, e
+        baz
+      end
+    `);
+
+    const expectedContent = ruby(`
+      case foo
+      in [*c, d, e]
+        baz
+      end
+    `);
+
+    expect(content).toChangeFormat(expectedContent);
+  });
+
+  test("_, _", () => {
+    const content = ruby(`
+      case foo
+      in _, _
+        baz
+      end
+    `);
+
+    const expectedContent = ruby(`
+      case foo
+      in [_, _]
+        baz
+      end
+    `);
+
+    expect(content).toChangeFormat(expectedContent);
+  });
+
+  test("a, b if b == a * 2", () => {
+    const content = ruby(`
+      case foo
+      in a, b if b == a * 2
+        baz
+      end
+    `);
+
+    const expectedContent = ruby(`
+      case foo
+      in [a, b] if b == a * 2
+        baz
+      end
+    `);
+
+    expect(content).toChangeFormat(expectedContent);
+  });
+
   test("with a single array element", () => {
     const content = ruby(`
       case value
@@ -76,7 +161,17 @@ describe("patterns", () => {
       end
     `);
 
-    expect(content).toMatchFormat();
+    const expectedContent = ruby(`
+      case foo
+      in [
+           1, # 1 comment
+           2
+         ] # 2 comment
+        bar
+      end
+    `);
+
+    expect(content).toChangeFormat(expectedContent);
   });
 
   test("multiple clauses", () => {

--- a/test/js/ruby/nodes/strings.test.js
+++ b/test/js/ruby/nodes/strings.test.js
@@ -88,8 +88,8 @@ describe("strings", () => {
       expect(`"abc's"`).toMatchFormat();
     });
 
-    test("double quotes get escaped", () => {
-      expect(`'"foo"'`).toChangeFormat(`"\\"foo\\""`);
+    test("double quotes do not get escaped if it results in more quotes", () => {
+      expect(`'"foo"'`).toMatchFormat();
     });
 
     describe("escape sequences", () => {


### PR DESCRIPTION
Fixes some tests that were failing on main due to changes in `syntax_tree`.

- Split a bunch of patterns out into their own tests where the content is different.
- Updates a test that is no longer escaping quotes where it used to.
- Bumps `syntax_tree` dependency to `>= 2.7.1`