### PR TITLE
Run Rake task in check mode if write disabled

### DIFF
--- a/lib/prettier/rake/task.rb
+++ b/lib/prettier/rake/task.rb
@@ -49,7 +49,7 @@ module Prettier
       end
 
       def run_task
-        Prettier.run([("--write" if write), source_files].compact)
+        Prettier.run([write ? "--write" : "--check", source_files].compact)
         exit($?.exitstatus) if $?&.exited?
       end
     end


### PR DESCRIPTION
While I understand there may be value to printing out the contents of the files being parsed, I think that running the rake task in check mode if write is disabled is a more sensible mode of operation. This allows me to write a rake task for running prettier in CI.