### PR TITLE
add back support for standard prettier config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,14 @@ The `prettier` executable is now installed and ready for use:
 
 Below are the options (from [`src/plugin.js`](src/plugin.js)) that `@prettier/plugin-ruby` currently supports:
 
-| API Option      | CLI Option         | Default | Description                                                                                                                 |
-| --------------- | ------------------ | :-----: | --------------------------------------------------------------------------------------------------------------------------- |
-| `printWidth`    | `--print-width`    |  `80`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#print-width)).                            |
-| `requirePragma` | `--require-pragma` | `false` | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#require-pragma)).                         |
-| `rubyPlugins`   | `--ruby-plugins`   |  `""`   | The comma-separated list of plugins to require. See [Syntax Tree](https://github.com/ruby-syntax-tree/syntax_tree#plugins). |
-| `tabWidth`      | `--tab-width`      |   `2`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#tab-width)).                              |
+| API Option      | CLI Option         | Default | Description                                                                                                                                         |
+| --------------- | ------------------ | :-----: | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `printWidth`    | `--print-width`    |  `80`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#print-width)).                                                    |
+| `requirePragma` | `--require-pragma` | `false` | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#require-pragma)).                                                 |
+| `rubyPlugins`   | `--ruby-plugins`   |  `""`   | The comma-separated list of plugins to require. See [Syntax Tree](https://github.com/ruby-syntax-tree/syntax_tree#plugins).                         |
+| `tabWidth`      | `--tab-width`      |   `2`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#tab-width)).                                                      |
+| `singleQuote`   | `--single-quote`   | `false` | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#quotes)).                                                         |
+| `trailingComma` | `--trailing-comma` |  `es5`  | Almost same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#trailing-commas)). Will be on for any value except `none`. |
 
 Any of these can be added to your existing [prettier configuration
 file](https://prettier.io/docs/en/configuration.html). For example:

--- a/src/parseSync.js
+++ b/src/parseSync.js
@@ -114,9 +114,20 @@ function spawnServer(opts) {
     };
   }
 
+  const plugins = new Set(opts.rubyPlugins.split(","));
+  if (opts.singleQuote) {
+    plugins.add("plugin/single_quotes");
+  }
+
+  if (opts.trailingComma !== "none") {
+    plugins.add("plugin/trailing_comma");
+  }
+
+  const rubyPlugins = Array.from(plugins).join(",");
+
   const server = spawn(
     "ruby",
-    [serverRbPath, `--plugins=${opts.rubyPlugins}`, filepath],
+    [serverRbPath, `--plugins=${rubyPlugins}`, filepath],
     {
       env: Object.assign({}, process.env, { LANG: getLang() }),
       detached: true,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -163,7 +163,9 @@ const plugin = {
   },
   defaultOptions: {
     printWidth: 80,
-    tabWidth: 2
+    tabWidth: 2,
+    trailingComma: "none",
+    singleQuote: false
   }
 };
 


### PR DESCRIPTION
Feels like the whole point of `prettier` is that 1 `.prettierrc` sets the config for the whole project. So, to me, it's a little weird that the ruby plugin has different options to the standard package

Couldn't find any tests for single quotes or trailing commas in the codebase, and not 100% sure where they should go, so happy to add some if you point me to where.

Closes #1239