### PR TITLE
Make haml/rbs dependencies optional

### DIFF
--- a/src/server.rb
+++ b/src/server.rb
@@ -6,6 +6,18 @@ require "socket"
 
 require "syntax_tree"
 
+# Optional dependencies
+%W[
+  syntax_tree/rbs
+  syntax_tree/haml
+  prettier_print
+].each do |dep|
+  begin
+    require dep
+  rescue LoadError
+  end
+end
+
 # First, require all of the plugins that the user specified.
 ARGV.shift[/^--plugins=(.*)$/, 1]
   .split(",")
@@ -97,7 +109,6 @@ listener =
             formatter.flush
             formatter.output.join
           when "rbs"
-            require "syntax_tree/rbs"
             formatter =
               SyntaxTree::RBS::Formatter.new(
                 source,
@@ -110,8 +121,6 @@ listener =
             formatter.flush
             formatter.output.join
           when "haml"
-            require "syntax_tree/haml"
-            require "prettier_print"
             formatter =
               if defined?(SyntaxTree::Haml::Format::Formatter)
                 SyntaxTree::Haml::Format::Formatter.new(

--- a/src/server.rb
+++ b/src/server.rb
@@ -4,10 +4,7 @@ require "bundler/setup"
 require "json"
 require "socket"
 
-require "prettier_print"
 require "syntax_tree"
-require "syntax_tree/haml"
-require "syntax_tree/rbs"
 
 # First, require all of the plugins that the user specified.
 ARGV.shift[/^--plugins=(.*)$/, 1]
@@ -100,6 +97,7 @@ listener =
             formatter.flush
             formatter.output.join
           when "rbs"
+            require "syntax_tree/rbs"
             formatter =
               SyntaxTree::RBS::Formatter.new(
                 source,
@@ -112,6 +110,8 @@ listener =
             formatter.flush
             formatter.output.join
           when "haml"
+            require "syntax_tree/haml"
+            require "prettier_print"
             formatter =
               if defined?(SyntaxTree::Haml::Format::Formatter)
                 SyntaxTree::Haml::Format::Formatter.new(

--- a/src/server.rb
+++ b/src/server.rb
@@ -7,11 +7,7 @@ require "socket"
 require "syntax_tree"
 
 # Optional dependencies
-%W[
-  syntax_tree/rbs
-  syntax_tree/haml
-  prettier_print
-].each do |dep|
+%W[syntax_tree/rbs syntax_tree/haml prettier_print].each do |dep|
   begin
     require dep
   rescue LoadError


### PR DESCRIPTION
👋 Hey, thanks for this plugin. 

Right now this plugin requires you to install the dependencies for formatting haml and rbs files, even if your codebase isn't using those types of files. This PR modifies `src/server.rb` so these formatting dependencies are ~~only required "on demand" - e.g., when the server is actually processing a haml or rbs file~~ only required optionally.

This change will mean we can drop `haml` as a dependency in our codebase, since it's only being imported so that we can format ruby files with this plugin.