### PR TITLE
New eslint config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-/coverage/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,21 @@
+import js from "@eslint/js";
+import eslintConfigPrettier from "eslint-config-prettier";
+
+export default [
+  js.configs.recommended,
+  eslintConfigPrettier,
+  {
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: "module",
+      globals: {
+        node: "readonly",
+        jest: "readonly"
+      }
+    },
+    rules: {
+      "no-undef": "off"
+    },
+    ignores: ["/coverage/"]
+  }
+];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import js from "@eslint/js";
 import eslintConfigPrettier from "eslint-config-prettier";
 
 export default [
+  { ignores: ["/coverage/"] },
   js.configs.recommended,
   eslintConfigPrettier,
   {
@@ -15,7 +16,6 @@ export default [
     },
     rules: {
       "no-undef": "off"
-    },
-    ignores: ["/coverage/"]
+    }
   }
 ];

--- a/package.json
+++ b/package.json
@@ -23,29 +23,13 @@
     "prettier": "^3.0.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.1.1",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^9.0.0",
     "husky": "^9.0.2",
     "jest": "^29.5.0",
     "prettier": "^3.1.0",
     "pretty-quick": "^4.0.0"
-  },
-  "eslintConfig": {
-    "extends": [
-      "eslint:recommended",
-      "prettier"
-    ],
-    "env": {
-      "jest": true,
-      "node": true
-    },
-    "parserOptions": {
-      "ecmaVersion": 2020,
-      "sourceType": "module"
-    },
-    "rules": {
-      "no-undef": "off"
-    }
   },
   "jest": {
     "globalSetup": "./test/js/globalSetup.js",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -105,7 +105,7 @@ export async function spawnServer(opts, killOnExit = true) {
           const pid = process.platform === "win32" ? server.pid : -server.pid;
           process.kill(pid);
         }
-      } catch (error) {
+      } catch {
         // If there's an error killing the process, we're going to ignore it.
       }
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,7 +329,7 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@9.1.1":
+"@eslint/js@9.1.1", "@eslint/js@^9.1.1":
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.1.1.tgz#eb0f82461d12779bbafc1b5045cde3143d350a8a"
   integrity sha512-5WoDz3Y19Bg2BnErkZTp0en+c/i9PvgFS7MBe1+m60HjFr0hrphlAGp4yzI7pxpt4xShln4ZyYp4neJm8hmOkQ==


### PR DESCRIPTION
On main, running `yarn lint` produces some errors because of the new [flat config](https://eslint.org/docs/latest/use/migrate-to-9.0.0#flat-config) in ESLint v9.0.0 (broken in 6e472faa795228f0a9821f78739ae2a1a03de0ef)

```sh
❯ yarn lint
yarn run v1.22.22
$ eslint --cache .
(node:2502) ESLintIgnoreWarning: The ".eslintignore" file is no longer supported. Switch to using the "ignores" property in "eslint.config.js": https://eslint.org/docs/latest/use/configure/migration-guide#ignoring-files
(Use `node --trace-warnings ...` to show where the warning was created)

Oops! Something went wrong! :(

ESLint: 9.1.0

Error: Could not find config file.
...
```

This PR updates to the new ESLint flat config and also [fixes one error](https://github.com/prettier/plugin-ruby/commit/87db4336dc9691ed9708f6b8d3eabe02256b6be2) from successfully running `yarn lint`