### PR TITLE
Allow plugin to run if prettier config is missing

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -76,7 +76,9 @@ export async function spawnServer(opts, killOnExit = true) {
 
   if (opts.filepath) {
     const prettierConfig = await resolveConfigFile(opts.filepath);
-    options.cwd = path.dirname(prettierConfig);
+    if (prettierConfig) {
+      options.cwd = path.dirname(prettierConfig);
+    }
   }
 
   const server = spawn(


### PR DESCRIPTION
If there is no prettier config in a project, but the plugin is specified in the CLI invocation of prettier, the plugin raises with an difficult to understand error message:

```sh
❯ npx prettier --plugin=@prettier/plugin-ruby --check .
Checking formatting...
script.rb
[error] script.rb: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received null
[error]     at Object.dirname (node:path:1279:5)
[error]     at spawnServer (file:///private/tmp/foo/node_modules/@prettier/plugin-ruby/src/plugin.js:79:24)
[error]     at async parse (file:///private/tmp/foo/node_modules/@prettier/plugin-ruby/src/plugin.js:154:27)
[error]     at async parse4 (file:///private/tmp/foo/node_modules/prettier/index.mjs:22117:11)
[error]     at async coreFormat (file:///private/tmp/foo/node_modules/prettier/index.mjs:22607:7)
[error]     at async formatWithCursor (file:///private/tmp/foo/node_modules/prettier/index.mjs:22809:14)
[error]     at async formatFiles (file:///private/tmp/foo/node_modules/prettier/internal/cli.mjs:6673:18)
[error]     at async main (file:///private/tmp/foo/node_modules/prettier/internal/cli.mjs:7081:5)
[error]     at async Module.run (file:///private/tmp/foo/node_modules/prettier/internal/cli.mjs:7027:5)
```

This allows the plugin to run anyway. Is that a problem? Should a clearer error be thrown here instead?

Notably, `opts.filepath` seems to always be defined AFAICT