### PR TITLE
Use shell for spawned server

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -71,7 +71,8 @@ export async function spawnServer(opts, killOnExit = true) {
   const options = {
     env: Object.assign({}, process.env, { LANG: getLang() }),
     stdio: ["ignore", "ignore", "inherit"],
-    detached: true
+    detached: true,
+    shell: true // TODO: allow user to select shell
   };
 
   if (opts.filepath) {


### PR DESCRIPTION
Allows user to select what ruby binary is run at the end. e.g with rvm  only enabled ruby binary this can be handy