### PR TITLE
Remove bundler dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ yarn add --dev prettier @prettier/plugin-ruby
 You'll also need to add the necessary Ruby dependencies. You can do this by running:
 
 ```bash
-gem install bundler prettier_print syntax_tree syntax_tree-haml syntax_tree-rbs
+gem install prettier_print syntax_tree syntax_tree-haml syntax_tree-rbs
 ```
 
 The `prettier` executable is now installed and ready for use:

--- a/src/server.rb
+++ b/src/server.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/setup"
 require "json"
 require "socket"
 


### PR DESCRIPTION
I had an issue where my default ruby version with rvm was 3.2.2 but my project was using 3.1.4.

By requiring bundler/setup from server.rb resulted to:

.rvm/gems/ruby-3.2.2/gems/bundler-2.5.10/lib/bundler/definition.rb:452:in `validate_ruby!': Your Ruby version is 3.2.2, but your Gemfile specified 3.1.4 (Bundler::RubyVersionMismatch)

I couldn't understand what problems bundler was resolving so I think it can be just removed.
